### PR TITLE
Add warning when using templates in service dev tools

### DIFF
--- a/src/panels/developer-tools/service/developer-tools-service.ts
+++ b/src/panels/developer-tools/service/developer-tools-service.ts
@@ -200,13 +200,13 @@ class HaPanelDevService extends LitElement {
       return false;
     }
 
-    this._error = undefined;
     if (hasTemplate(this._serviceData!)) {
       this._error = this.hass.localize(
         "ui.panel.developer-tools.tabs.services.no_templates"
       );
       return false;
     }
+    this._error = undefined;
 
     const domain = computeDomain(serviceData.service);
     const service = computeObjectId(serviceData.service);

--- a/src/panels/developer-tools/service/developer-tools-service.ts
+++ b/src/panels/developer-tools/service/developer-tools-service.ts
@@ -199,6 +199,15 @@ class HaPanelDevService extends LitElement {
     if (!serviceData?.service) {
       return false;
     }
+
+    this._error = undefined;
+    if (hasTemplate(this._serviceData!)) {
+      this._error = this.hass.localize(
+        "ui.panel.developer-tools.tabs.services.no_templates"
+      );
+      return false;
+    }
+
     const domain = computeDomain(serviceData.service);
     const service = computeObjectId(serviceData.service);
     if (!domain || !service) {
@@ -257,14 +266,6 @@ class HaPanelDevService extends LitElement {
     const domain = computeDomain(this._serviceData!.service);
     const service = computeObjectId(this._serviceData!.service);
     if (!domain || !service) {
-      return;
-    }
-
-    this._error = undefined;
-    if (hasTemplate(this._serviceData!)) {
-      this._error = this.hass.localize(
-        "ui.panel.developer-tools.tabs.services.no_templates"
-      );
       return;
     }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3340,7 +3340,8 @@
             "ui_mode": "Go to UI mode",
             "yaml_parameters": "Parameters only available in YAML mode",
             "all_parameters": "All available parameters",
-            "accepts_target": "This service accepts a target, for example: `entity_id: light.bed_light`"
+            "accepts_target": "This service accepts a target, for example: `entity_id: light.bed_light`",
+            "no_templates": "The service dev tools does not support the use of Jinja templates"
           },
           "states": {
             "title": "States",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds a warning to the service dev tools, when using templates:

![2021-03-12 12 49 24](https://user-images.githubusercontent.com/195327/110936636-7e44b400-8331-11eb-997b-82645d036376.gif)


PS: I have no idea what I'm doing 😬 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
