### PR TITLE
"sidebar" view: allow to scroll "main" area w/o scrolling a sidebar

### DIFF
--- a/src/panels/lovelace/views/hui-sidebar-view.ts
+++ b/src/panels/lovelace/views/hui-sidebar-view.ts
@@ -214,6 +214,15 @@ export class SideBarView extends LitElement implements LovelaceViewElement {
       #main {
         max-width: 1620px;
         flex-grow: 2;
+        max-height: calc(100vh);
+        overflow-y: auto;
+      }
+
+      @media (max-width: 760px) {
+        #main {
+          max-height: unset;
+          overflow-y: unset;
+        }
       }
 
       #sidebar {

--- a/src/panels/lovelace/views/hui-sidebar-view.ts
+++ b/src/panels/lovelace/views/hui-sidebar-view.ts
@@ -214,7 +214,7 @@ export class SideBarView extends LitElement implements LovelaceViewElement {
       #main {
         max-width: 1620px;
         flex-grow: 2;
-        max-height: calc(100vh);
+        max-height: calc(100vh - var(--header-height) - 4px);
         overflow-y: auto;
       }
 


### PR DESCRIPTION
Currently in a "Sidebar view" the whole page is scrolling down if needed.
This PR allows to scroll the "main area" independently of a "sidebar area".
Available only if the "main area" is NOT in one column with the "sidebar area".
This is mainly useful for tablets (ofc for desktops as well).

Tested on 1920x1200 desktop, iPad Air 2, iPhone 5S (real devices, not emulators).

![side1](https://github.com/home-assistant/frontend/assets/71872483/d7691a07-2071-4901-8688-de54748a1fc5)

![side2](https://github.com/home-assistant/frontend/assets/71872483/489fc8c5-8500-4a76-b11a-7afcc291b6e8)


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
