### PR TITLE
cover: Disable stop button when not opening/closing

### DIFF
--- a/src/data/cover.ts
+++ b/src/data/cover.ts
@@ -77,7 +77,11 @@ export function canClose(stateObj: CoverEntity): boolean {
 }
 
 export function canStop(stateObj: CoverEntity): boolean {
-  return stateObj.state !== UNAVAILABLE;
+  if (stateObj.state === UNAVAILABLE) {
+    return false;
+  }
+  const assumedState = stateObj.attributes.assumed_state === true;
+  return isOpening(stateObj) || isClosing(stateObj) || assumedState;
 }
 
 export function canOpenTilt(stateObj: CoverEntity): boolean {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Disable the stop button when the cover is not moving.

Fixes/implements the below quoted part of issue: #17945:

> Cover button states are not dependent on `CoverOperation`
> ## `COVER_OPERATION_IDLE`
> ### ■ button state
> 
> ■ button is always enabled (when `stop_action` is set) regardless of the cover state and operation (even when `COVER_OPERATION_IDLE`)
> 
> Cover Open
![image](https://private-user-images.githubusercontent.com/2578772/260232788-41434348-acc9-402b-a15f-988a09987d19.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDE3MDQ2NzksIm5iZiI6MTcwMTcwNDM3OSwicGF0aCI6Ii8yNTc4NzcyLzI2MDIzMjc4OC00MTQzNDM0OC1hY2M5LTQwMmItYTE1Zi05ODhhMDk5ODdkMTkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQUlXTkpZQVg0Q1NWRUg1M0ElMkYyMDIzMTIwNCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzEyMDRUMTUzOTM5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9OGFhYTM5OTA4NjA0ZjFlMTc2NTlhMTdjMTU5Yzc3NzI1ZjNjZjgzZGU4MThmY2JhYzI0ZjllY2EyYWQ4N2Y5OCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.Z6coKxuWSnlpWr-n-2AwH5ZosxlGCZnLf3w2QH8-j8s)
Cover Closed
![image](https://private-user-images.githubusercontent.com/2578772/260232824-362ba4ae-7091-48f0-a2a6-9212aa59d264.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDE3MDQ2NzksIm5iZiI6MTcwMTcwNDM3OSwicGF0aCI6Ii8yNTc4NzcyLzI2MDIzMjgyNC0zNjJiYTRhZS03MDkxLTQ4ZjAtYTJhNi05MjEyYWE1OWQyNjQucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQUlXTkpZQVg0Q1NWRUg1M0ElMkYyMDIzMTIwNCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzEyMDRUMTUzOTM5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9M2Y2OTc2ODk1MDVkMjJkOGNlMGM5MDYzMWU4Yzg3NmE4NzlhZGM5MzRiNzM5MTZhYWU4MTQ4MmYzNjhmYTgzYyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.9oRUy3t7OQ9PkfqfET25aET_duz__cmDnV2nR1xeRis)
> 
> ■ button is expected to be
> 
>    * **disabled** when `COVER_OPERATION_IDLE`
> 
>    * **enabled** otherwise (`COVER_OPERATION_OPENING` or `COVER_OPERATION_CLOSING`)
> 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17945
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
