### PR TITLE
Proposal for a new scene editor

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3413,6 +3413,8 @@
           },
           "editor": {
             "default_name": "New scene",
+            "capture": "Capture",
+            "capture_all": "Capture all",
             "load_error_not_editable": "Only scenes in scenes.yaml are editable.",
             "load_error_unknown": "Error loading scene ({err_no}).",
             "save": "Save",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
A change to the current behavior of the scene editor is currently one of the most-voted requested features, and I spent a little time thinking about an alternative behavior that might be more user friendly and less surprising. I came up with the following:

In this proposal scenes are no longer activated simply because the scene editor is opened. Instead of yoking the config in the scene editor to the live status of all the devices in the scene, add a "capture" button for each device/entity that allows user to copy the current state of that device only into their scene. This allows decoupling the current state from the scene being edited. 

By using this behavior, scene can be partially edited without having to take live the state of all other devices in the scene, and user can pick and choose which to update. Capture button also serves as an indicator that the current state of the device is not equal to the state saved in the scene.

This also adds an "Activate" button to the overflow menu, in case user wants to choose to activate the full scene. 

As a possible enhancement, because the scene config state is decoupled from the live state, this would allow for adding a yaml editor here to allow for fine tweaking the scene state in yaml (similar to how automations elements can be edited in ui or yaml). But that has not been implemented yet. 

Hasn't been tested that extensively yet, but just wanted to get an idea of if the UI might be something we would want to go for.

![image](https://github.com/home-assistant/frontend/assets/32912880/cae9c5fb-ecf6-41c8-8df2-7a00b8971a91)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/improve-scene-editor-allow-scene-edits-without-setting-devices-states/151053
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced scene management capabilities in the HaSceneEditor, allowing users to capture and manage changes to scene entities.
	- Introduced a feature to capture all dirty entities with a streamlined UI.
- **Improvements**
	- Improved state management for unsaved changes, ensuring more responsive user interactions.
	- Updated localization with new strings for better clarity in the editor's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->