### PR TITLE
Add advanced diagram showing flow of electrical energy/power

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@codemirror/search": "6.5.6",
     "@codemirror/state": "6.4.1",
     "@codemirror/view": "6.26.3",
+    "@davethompson/elec-sankey": "1.0.0",
     "@egjs/hammerjs": "2.0.17",
     "@formatjs/intl-datetimeformat": "6.12.3",
     "@formatjs/intl-displaynames": "6.6.6",

--- a/src/components/chart/ha-elec-sankey.ts
+++ b/src/components/chart/ha-elec-sankey.ts
@@ -1,0 +1,91 @@
+import { customElement, property } from "lit/decorators";
+
+import { CSSResultArray, TemplateResult, css, html, nothing } from "lit";
+import { mdiArrowLeft, mdiArrowRight } from "@mdi/js";
+import { ElecSankey } from "@davethompson/elec-sankey";
+import { HomeAssistant } from "../../types";
+import { formatNumber } from "../../common/number/format_number";
+import "../ha-icon";
+import { fireEvent } from "../../common/dom/fire_event";
+
+@customElement("ha-elec-sankey")
+export class HaElecSankey extends ElecSankey {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  protected _generateLabelDiv(
+    id: string | undefined,
+    icon: string | undefined,
+    _name: string | undefined,
+    valueA: number,
+    valueB: number | undefined
+  ): TemplateResult {
+    const _id = id || "";
+    return html`
+      <div
+        class=${id ? "label label-action-clickable" : "label"}
+        id=${_id}
+        @click=${id ? this._handleMoreInfo : nothing}
+      >
+        ${_name || nothing}
+        ${icon
+          ? html`<ha-svg-icon id=${_id} .path=${icon}> </ha-svg-icon><br />`
+          : nothing}
+        ${valueB !== undefined
+          ? html` <span class="return" id=${_id}>
+                <ha-svg-icon id=${_id} class="small" .path=${mdiArrowLeft}>
+                </ha-svg-icon
+                >${formatNumber(valueB, this.hass.locale, {
+                  maximumFractionDigits: 1,
+                })}&nbsp;${this.unit}</span
+              ><br />
+              <span class="consumption" id=${_id}>
+                <ha-svg-icon id=${_id} class="small" .path=${mdiArrowRight}>
+                </ha-svg-icon
+                >${formatNumber(valueA, this.hass.locale, {
+                  maximumFractionDigits: 1,
+                })}&nbsp;${this.unit}
+              </span>`
+          : html`${formatNumber(valueA, this.hass.locale, {
+              maximumFractionDigits: 1,
+            })}&nbsp;${this.unit}`}
+      </div>
+    `;
+  }
+
+  private _handleMoreInfo(e: MouseEvent) {
+    const div = e.target as HTMLDivElement;
+    fireEvent(this, "hass-more-info", {
+      entityId: div.id,
+    });
+  }
+
+  static styles: CSSResultArray = [
+    ElecSankey.styles,
+    css`
+      .label {
+        font-size: 12px;
+      }
+      .label-action-clickable {
+        cursor: pointer;
+      }
+      ha-svg-icon {
+        --icon-primary-color: var(--icon-primary-color);
+      }
+      ha-svg-icon.small {
+        --mdc-icon-size: 12px;
+      }
+      .consumption {
+        color: var(--energy-grid-consumption-color);
+      }
+      .return {
+        color: var(--energy-grid-return-color);
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-elec-sankey": HaElecSankey;
+  }
+}

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -80,6 +80,11 @@ export class EnergyViewStrategy extends ReactiveElement {
         type: "energy-solar-graph",
         collection_key: "energy_dashboard",
       });
+      view.cards!.push({
+        title: hass.localize("ui.panel.energy.cards.energy_elec_flow_title"),
+        type: "energy-elec-flow",
+        collection_key: "energy_dashboard",
+      });
     }
 
     // Only include if we have a gas source.

--- a/src/panels/lovelace/cards/energy/hui-energy-elec-flow-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-elec-flow-card.ts
@@ -1,0 +1,194 @@
+/**
+ * @todo
+ * - Verify what happens if incomplete data set is provided e.g.
+ *   - grid but no generation,
+ *   - no consumers
+ *   - no grid
+ *   - etc
+ */
+import { mdiSolarPower } from "@mdi/js";
+import { UnsubscribeFunc } from "home-assistant-js-websocket";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+
+import "../../../../components/chart/ha-chart-base";
+import "../../../../components/ha-card";
+import type { ElecRoute } from "@davethompson/elec-sankey";
+import "@davethompson/elec-sankey";
+import {
+  DeviceConsumptionEnergyPreference,
+  EnergyData,
+  energySourcesByType,
+  getEnergyDataCollection,
+  SolarSourceTypeEnergyPreference,
+} from "../../../../data/energy";
+import {
+  calculateStatisticsSumGrowth,
+  getStatisticLabel,
+} from "../../../../data/recorder";
+import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
+import { HomeAssistant } from "../../../../types";
+import { LovelaceCard } from "../../types";
+import { EnergyElecFlowCardConfig } from "../types";
+import "../../../../components/chart/ha-elec-sankey";
+
+@customElement("hui-energy-elec-flow-card")
+export class HuiEnergyElecFlowCard
+  extends SubscribeMixin(LitElement)
+  implements LovelaceCard
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _config?: EnergyElecFlowCardConfig;
+
+  @state() private _gridInRoute?: ElecRoute;
+
+  @state() private _gridOutRoute?: ElecRoute;
+
+  @state() private _generationInRoutes: { [id: string]: ElecRoute } = {};
+
+  @state() private _consumerRoutes: { [id: string]: ElecRoute } = {};
+
+  protected hassSubscribeRequiredHostProps = ["_config"];
+
+  public hassSubscribe(): UnsubscribeFunc[] {
+    return [
+      getEnergyDataCollection(this.hass, {
+        key: this._config?.collection_key,
+      }).subscribe((data) => this._getStatistics(data)),
+    ];
+  }
+
+  public getCardSize(): Promise<number> | number {
+    return 3;
+  }
+
+  public setConfig(config: EnergyElecFlowCardConfig): void {
+    this._config = config;
+  }
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+    return html`
+      <ha-card>
+        ${this._config.title
+          ? html`<h1 class="card-header">${this._config.title}</h1>`
+          : ""}
+        <div
+          class="content ${classMap({
+            "has-header": !!this._config.title,
+          })}"
+        >
+          <ha-elec-sankey
+            .hass=${this.hass}
+            .gridInRoute=${this._gridInRoute ? this._gridInRoute : undefined}
+            .gridOutRoute=${this._gridOutRoute ? this._gridOutRoute : undefined}
+            .generationInRoutes=${this._generationInRoutes
+              ? this._generationInRoutes
+              : {}}
+            .consumerRoutes=${this._consumerRoutes ? this._consumerRoutes : {}}
+          ></ha-elec-sankey>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  private async _getStatistics(energyData: EnergyData): Promise<void> {
+    const solarSources: SolarSourceTypeEnergyPreference[] =
+      energyData.prefs.energy_sources.filter(
+        (source) => source.type === "solar"
+      ) as SolarSourceTypeEnergyPreference[];
+
+    const prefs = energyData.prefs;
+    const types = energySourcesByType(prefs);
+
+    const totalFromGrid =
+      calculateStatisticsSumGrowth(
+        energyData.stats,
+        types.grid![0].flow_from.map((flow) => flow.stat_energy_from)
+      ) ?? 0;
+    this._gridInRoute = {
+      id: "grid-in-all",
+      rate: totalFromGrid,
+    };
+
+    const totalToGrid =
+      calculateStatisticsSumGrowth(
+        energyData.stats,
+        types.grid![0].flow_to.map((flow) => flow.stat_energy_to)
+      ) ?? 0;
+    this._gridOutRoute = {
+      id: "grid-out-all",
+      rate: totalToGrid,
+    };
+
+    solarSources.forEach((source) => {
+      const label = getStatisticLabel(
+        this.hass,
+        source.stat_energy_from,
+        undefined
+      );
+
+      const value = calculateStatisticsSumGrowth(energyData.stats, [
+        source.stat_energy_from,
+      ]);
+      if (!(source.stat_energy_from in this._generationInRoutes)) {
+        this._generationInRoutes[source.stat_energy_from] = {
+          id: source.stat_energy_from,
+          text: label,
+          rate: value ?? 0,
+          icon: mdiSolarPower,
+        };
+      } else {
+        this._generationInRoutes[source.stat_energy_from].rate = value ?? 0;
+      }
+    });
+
+    const consumers: DeviceConsumptionEnergyPreference[] = energyData.prefs
+      .device_consumption as DeviceConsumptionEnergyPreference[];
+
+    consumers.forEach((consumer) => {
+      const label = getStatisticLabel(
+        this.hass,
+        consumer.stat_consumption,
+        undefined
+      );
+      const value = calculateStatisticsSumGrowth(energyData.stats, [
+        consumer.stat_consumption,
+      ]);
+      if (!(consumer.stat_consumption in this._consumerRoutes)) {
+        this._consumerRoutes[consumer.stat_consumption] = {
+          id: consumer.stat_consumption,
+          text: label,
+          rate: value ?? 0,
+          icon: undefined,
+        };
+      } else {
+        this._consumerRoutes[consumer.stat_consumption].rate = value ?? 0;
+      }
+    });
+  }
+
+  static styles = css`
+    ha-card {
+      height: 100%;
+      padding: 16px;
+    }
+    .card-header {
+      padding-bottom: 0;
+    }
+    ha-elec-sankey {
+      --generation-color: var(--energy-solar-color);
+      --grid-in-color: var(--energy-grid-consumption-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-energy-elec-flow-card": HuiEnergyElecFlowCard;
+  }
+}

--- a/src/panels/lovelace/cards/energy/hui-energy-elec-flow-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-elec-flow-card.ts
@@ -76,12 +76,10 @@ export class HuiEnergyElecFlowCard
         >
           <ha-elec-sankey
             .hass=${this.hass}
-            .gridInRoute=${this._gridInRoute ? this._gridInRoute : undefined}
-            .gridOutRoute=${this._gridOutRoute ? this._gridOutRoute : undefined}
-            .generationInRoutes=${this._generationInRoutes
-              ? this._generationInRoutes
-              : {}}
-            .consumerRoutes=${this._consumerRoutes ? this._consumerRoutes : {}}
+            .gridInRoute=${this._gridInRoute || undefined}
+            .gridOutRoute=${this._gridOutRoute || undefined}
+            .generationInRoutes=${this._generationInRoutes || {}}
+            .consumerRoutes=${this._consumerRoutes || {}}
           ></ha-elec-sankey>
         </div>
       </ha-card>

--- a/src/panels/lovelace/cards/energy/hui-energy-elec-flow-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-elec-flow-card.ts
@@ -1,11 +1,3 @@
-/**
- * @todo
- * - Verify what happens if incomplete data set is provided e.g.
- *   - grid but no generation,
- *   - no consumers
- *   - no grid
- *   - etc
- */
 import { mdiSolarPower } from "@mdi/js";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";

--- a/src/panels/lovelace/cards/hui-power-flow-card.ts
+++ b/src/panels/lovelace/cards/hui-power-flow-card.ts
@@ -1,0 +1,238 @@
+import { HassEntity } from "home-assistant-js-websocket/dist/types";
+import {
+  css,
+  html,
+  LitElement,
+  PropertyValues,
+  nothing,
+  CSSResultArray,
+} from "lit";
+import { mdiSolarPower } from "@mdi/js";
+import { customElement, property, state } from "lit/decorators";
+import { ElecRoute } from "@davethompson/elec-sankey";
+import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
+import { computeStateName } from "../../../common/entity/compute_state_name";
+import { isValidEntityId } from "../../../common/entity/valid_entity_id";
+import "../../../components/ha-card";
+import type { HomeAssistant } from "../../../types";
+import { createEntityNotFoundWarning } from "../components/hui-warning";
+import type { LovelaceCard } from "../types";
+import type { PowerFlowCardConfig } from "./types";
+import "../../../components/chart/ha-elec-sankey";
+import { hasConfigChanged } from "../common/has-changed";
+
+export const DEFAULT_MIN = 0;
+export const DEFAULT_MAX = 100;
+
+@customElement("hui-power-flow-card")
+class HuiPowerFlowCard extends LitElement implements LovelaceCard {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _config?: PowerFlowCardConfig;
+
+  public getCardSize(): number {
+    return 3;
+  }
+
+  public setConfig(config: PowerFlowCardConfig): void {
+    if (
+      !config.power_from_grid_entity &&
+      !config.power_to_grid_entity &&
+      !config.generation_entities &&
+      !config.consumer_entities
+    ) {
+      throw new Error("Must specify at least one entity");
+    }
+    if (config.power_from_grid_entity) {
+      if (!isValidEntityId(config.power_from_grid_entity)) {
+        throw new Error("Invalid power from grid entity specified");
+      }
+      // @todo consider adding more config checks here.
+      this._config = { ...config };
+    }
+  }
+
+  protected render() {
+    if (!this._config || !this.hass) {
+      return nothing;
+    }
+    let gridInRoute: ElecRoute | null = null;
+    if (this._config.power_from_grid_entity) {
+      const stateObj = this.hass.states[this._config.power_from_grid_entity];
+      if (!stateObj) {
+        return html`
+          <hui-warning>
+            ${createEntityNotFoundWarning(
+              this.hass,
+              this._config.power_from_grid_entity
+            )}
+          </hui-warning>
+        `;
+      }
+      const name = computeStateName(stateObj);
+      gridInRoute = {
+        id: this._config.power_from_grid_entity,
+        text: name,
+        rate: Number(stateObj.state),
+      };
+    }
+
+    let gridOutRoute: ElecRoute | null = null;
+    if (this._config.power_to_grid_entity) {
+      const stateObj = this.hass.states[this._config.power_to_grid_entity];
+      if (!stateObj) {
+        return html`
+          <hui-warning>
+            ${createEntityNotFoundWarning(
+              this.hass,
+              this._config.power_to_grid_entity
+            )}
+          </hui-warning>
+        `;
+      }
+      const name = computeStateName(stateObj);
+      gridOutRoute = {
+        id: this._config.power_to_grid_entity,
+        text: name,
+        rate: Number(stateObj.state),
+      };
+    }
+
+    const generationInRoutes: { [id: string]: ElecRoute } = {};
+    if (this._config.generation_entities) {
+      for (const entity of this._config.generation_entities) {
+        const stateObj = this.hass.states[entity];
+        if (!stateObj) {
+          return html`
+            <hui-warning>
+              ${createEntityNotFoundWarning(this.hass, entity)}
+            </hui-warning>
+          `;
+        }
+        const name = computeStateName(stateObj);
+        generationInRoutes[entity] = {
+          id: entity,
+          text: name,
+          rate: Number(stateObj.state),
+          icon: mdiSolarPower,
+        };
+      }
+    }
+
+    const consumerRoutes: { [id: string]: ElecRoute } = {};
+    if (this._config.consumer_entities) {
+      for (const entity of this._config.consumer_entities) {
+        const stateObj = this.hass.states[entity];
+        if (!stateObj) {
+          return html`
+            <hui-warning>
+              ${createEntityNotFoundWarning(this.hass, entity)}
+            </hui-warning>
+          `;
+        }
+        const name = computeStateName(stateObj);
+        consumerRoutes[entity] = {
+          id: entity,
+          text: name,
+          rate: Number(stateObj.state),
+        };
+      }
+    }
+    return html`
+      <ha-card>
+        <ha-elec-sankey
+          .hass=${this.hass}
+          .unit=${"W"}
+          .gridInRoute=${gridInRoute || undefined}
+          .gridOutRoute=${gridOutRoute || undefined}
+          .generationInRoutes=${generationInRoutes}
+          .consumerRoutes=${consumerRoutes}
+        ></ha-elec-sankey>
+      </ha-card>
+    `;
+  }
+
+  protected shouldUpdate(changedProps: PropertyValues): boolean {
+    if (hasConfigChanged(this, changedProps)) {
+      return true;
+    }
+
+    if (!changedProps.has("hass")) {
+      return false;
+    }
+    const oldHass = changedProps.get("hass") as HomeAssistant;
+    const newHass = this.hass as HomeAssistant;
+
+    if (this._config) {
+      for (const id of [
+        this._config.power_from_grid_entity || [],
+        this._config.power_to_grid_entity || [],
+        ...(this._config.generation_entities || []),
+        ...(this._config.consumer_entities || []),
+      ]) {
+        const oldState = oldHass.states[id] as HassEntity | undefined;
+        const newState = newHass.states[id] as HassEntity | undefined;
+
+        if (oldState !== newState) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  protected updated(changedProps: PropertyValues): void {
+    super.updated(changedProps);
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+    const oldConfig = changedProps.get("_config") as
+      | PowerFlowCardConfig
+      | undefined;
+
+    if (
+      !oldHass ||
+      !oldConfig ||
+      oldHass.themes !== this.hass.themes ||
+      oldConfig.theme !== this._config.theme
+    ) {
+      applyThemesOnElement(this, this.hass.themes, this._config.theme);
+    }
+  }
+
+  static styles: CSSResultArray = [
+    css`
+      ha-card {
+        height: 100%;
+        padding: 16px;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        box-sizing: border-box;
+      }
+      ha-card:focus {
+        outline: none;
+      }
+      ha-elec-sankey {
+        --generation-color: var(--energy-solar-color);
+        --grid-in-color: var(--energy-grid-consumption-color);
+      }
+      .name {
+        text-align: center;
+        line-height: initial;
+        color: var(--primary-text-color);
+        width: 100%;
+        font-size: 15px;
+        margin-top: 8px;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-power-flow-card": HuiPowerFlowCard;
+  }
+}

--- a/src/panels/lovelace/cards/hui-power-flow-card.ts
+++ b/src/panels/lovelace/cards/hui-power-flow-card.ts
@@ -21,9 +21,6 @@ import type { PowerFlowCardConfig } from "./types";
 import "../../../components/chart/ha-elec-sankey";
 import { hasConfigChanged } from "../common/has-changed";
 
-export const DEFAULT_MIN = 0;
-export const DEFAULT_MAX = 100;
-
 @customElement("hui-power-flow-card")
 class HuiPowerFlowCard extends LitElement implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;

--- a/src/panels/lovelace/cards/hui-power-flow-card.ts
+++ b/src/panels/lovelace/cards/hui-power-flow-card.ts
@@ -162,16 +162,17 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
 
     if (this._config) {
       for (const id of [
-        this._config.power_from_grid_entity || [],
-        this._config.power_to_grid_entity || [],
+        this._config.power_from_grid_entity,
+        this._config.power_to_grid_entity,
         ...(this._config.generation_entities || []),
         ...(this._config.consumer_entities || []),
       ]) {
-        const oldState = oldHass.states[id] as HassEntity | undefined;
-        const newState = newHass.states[id] as HassEntity | undefined;
-
-        if (oldState !== newState) {
-          return true;
+        if (id) {
+          const oldState = oldHass.states[id] as HassEntity | undefined;
+          const newState = newHass.states[id] as HassEntity | undefined;
+          if (oldState !== newState) {
+            return true;
+          }
         }
       }
     }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -135,6 +135,11 @@ export interface EnergyUsageGraphCardConfig extends LovelaceCardConfig {
   title?: string;
   collection_key?: string;
 }
+export interface EnergyElecFlowCardConfig extends LovelaceCardConfig {
+  type: "energy-elec-flow";
+  title?: string;
+  collection_key?: string;
+}
 
 export interface EnergySolarGraphCardConfig extends LovelaceCardConfig {
   type: "energy-solar-graph";
@@ -235,6 +240,14 @@ export interface GaugeCardConfig extends LovelaceCardConfig {
   theme?: string;
   needle?: boolean;
   segments?: GaugeSegment[];
+}
+
+export interface PowerFlowCardConfig extends LovelaceCardConfig {
+  name?: string;
+  power_from_grid_entity?: string;
+  power_to_grid_entity?: string;
+  generation_entities?: string[];
+  consumer_entities?: string[];
 }
 
 export interface ConfigEntity extends EntityConfig {

--- a/src/panels/lovelace/create-element/create-card-element.ts
+++ b/src/panels/lovelace/create-element/create-card-element.ts
@@ -60,6 +60,7 @@ const LAZY_LOAD_TYPES = {
     import("../cards/energy/hui-energy-self-sufficiency-gauge-card"),
   "energy-solar-graph": () =>
     import("../cards/energy/hui-energy-solar-graph-card"),
+  "energy-elec-flow": () => import("../cards/energy/hui-energy-elec-flow-card"),
   "energy-sources-table": () =>
     import("../cards/energy/hui-energy-sources-table-card"),
   "energy-usage-graph": () =>
@@ -67,6 +68,7 @@ const LAZY_LOAD_TYPES = {
   "entity-filter": () => import("../cards/hui-entity-filter-card"),
   error: () => import("../cards/hui-error-card"),
   gauge: () => import("../cards/hui-gauge-card"),
+  "power-flow": () => import("../cards/hui-power-flow-card"),
   "history-graph": () => import("../cards/hui-history-graph-card"),
   "horizontal-stack": () => import("../cards/hui-horizontal-stack-card"),
   humidifier: () => import("../cards/hui-humidifier-card"),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6939,6 +6939,7 @@
         "cards": {
           "energy_usage_graph_title": "Energy usage",
           "energy_solar_graph_title": "Solar production",
+          "energy_elec_flow_title": "Energy flow",
           "energy_gas_graph_title": "Gas consumption",
           "energy_water_graph_title": "Water consumption",
           "energy_distribution_title": "Energy distribution",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,6 +1559,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@davethompson/elec-sankey@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@davethompson/elec-sankey@npm:1.0.0"
+  dependencies:
+    "@mdi/js": "npm:^7.4.47"
+    lit: "npm:^2.8.0"
+  checksum: 10/bbba605a0ea9356b8cd9d35697de15cb9cd333b1d8e2408d8882b0484fc614d0a152bafd68810d56e59f80fee73553bcb8f74a3e9c010afa5c6baf0f575db380
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^0.5.0":
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
@@ -3213,7 +3223,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdi/js@npm:7.4.47":
+"@mdi/js@npm:7.4.47, @mdi/js@npm:^7.4.47":
   version: 7.4.47
   resolution: "@mdi/js@npm:7.4.47"
   checksum: 10/c1a8fc82f23030bccc0cf324b13b73a0034d06140e79f8bc7b0e4e59275624c470e5ca6524d6141ad8c4fe3ad0f314c7af99afb3e38df163eb50d3b13b9eab17
@@ -8929,6 +8939,7 @@ __metadata:
     "@codemirror/search": "npm:6.5.6"
     "@codemirror/state": "npm:6.4.1"
     "@codemirror/view": "npm:6.26.3"
+    "@davethompson/elec-sankey": "npm:1.0.0"
     "@egjs/hammerjs": "npm:2.0.17"
     "@formatjs/intl-datetimeformat": "npm:6.12.3"
     "@formatjs/intl-displaynames": "npm:6.6.6"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

The functionality proposed by this closed PR is now available in the HACS custom component:
https://github.com/davet2001/energy-sankey


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR adds something I've been working on for a while - a [Sankey diagram](https://en.wikipedia.org/wiki/Sankey_diagram) showing flow of electricity. e.g.:

![image](https://github.com/home-assistant/frontend/assets/17680170/f13195f3-334e-4bd2-abd1-6a14412876d6)

There are two main cards:
 - a card for the energy dashboard which picks up the current user configuration, and shows the total _energy_ flow based on the selected time range.
 - a user configurable card showing the _power_ flow for a set of sensors. This represents the live power flow at the current moment.

Both are live and automatically updating. The cards try to display a coherent representation even if the data set is incomplete or physically impossible (e.g. exporting more than the total generated). This means it is ok for asynchronous updates to be made to any of the entities it is listening for. 

The width of the flows represents the amount, and the overall size of everything is automatically scaled so that no one part of the diagram becomes too wide.

The diagram dynamically scales to fit the size of the window it is in (mostly, see below).

I put the main guts of the sankey creation logic into it's own npm library. This is my first proper attempt at adding a component to the frontend, so I would hugely value any feedback/suggestions!

I've added the energy card to the energy dashboard strategy, meaning it is automatically displayed if you have a solar energy source configured, but that's really just to make it easier to experiment with and try it out. Maybe it should be added as an available (but not automatically enabled) card until enough people have put it through its paces.

Outstanding issues to solve:
- [ ] Sometimes there are thin dark lines between the blocks that make up the shapes, I believe this is caused by antialiasing, but I don't see an easy way of reducing/eliminating it, especially where the shapes are across two divs.
- [ ] I am not sure how to set the minimum width of the card, or what is the standard practice here. If I shrink the window horizontally, eventually the svg elements start to spill off the card. I'm sure that this is not the desired behaviour, but I don't know how to fix it (suggestions welcome!).
- [ ] If you stretch the card really wide, it sort of looks a bit silly. Perhaps that's not a major issue though.
- [ ] There are probably more edge cases to experiment with, such as multiple generation sources, grid configured with only input or output, and either of those being negative to represent flow in the opposite direction.

- [ ] Battery storage is not supported yet. That could be added in the future.

At this stage I'd like some general feedback/suggestions to see if I'm heading in the right direction.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: panel
title: Power Flow
cards:
  - type: power-flow
    power_from_grid_entity: input_number.grid_power_in
    power_to_grid_entity: input_number.grid_out_power_override
    generation_entities:
      - input_number.pv_generation
    consumer_entities:
      - input_number.sample1_input_number
      - input_number.sample2_input_number
      - input_number.sample_3_input_number
      - input_number.sample4_input_number
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
