### PR TITLE
Add confirmations to some interactive entity-rows

### DIFF
--- a/src/panels/lovelace/common/confirm-action.ts
+++ b/src/panels/lovelace/common/confirm-action.ts
@@ -1,0 +1,25 @@
+import type { ConfirmationRestrictionConfig } from "../../../data/lovelace/config/action";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
+import { HomeAssistant } from "../../../types";
+
+export const confirmAction = async (
+  node: HTMLElement,
+  hass: HomeAssistant,
+  config: ConfirmationRestrictionConfig,
+  action: string
+): Promise<boolean> => {
+  if (
+    config.exemptions &&
+    config.exemptions.some((e) => e.user === hass!.user?.id)
+  ) {
+    return true;
+  }
+
+  return showConfirmationDialog(node, {
+    text:
+      config.text ||
+      hass.localize("ui.panel.lovelace.cards.actions.action_confirmation", {
+        action,
+      }),
+  });
+};

--- a/src/panels/lovelace/editor/structs/action-struct.ts
+++ b/src/panels/lovelace/editor/structs/action-struct.ts
@@ -16,7 +16,7 @@ const actionConfigStructUser = object({
   user: string(),
 });
 
-const actionConfigStructConfirmation = union([
+export const actionConfigStructConfirmation = union([
   boolean(),
   object({
     text: optional(string()),

--- a/src/panels/lovelace/editor/structs/entities-struct.ts
+++ b/src/panels/lovelace/editor/structs/entities-struct.ts
@@ -1,6 +1,9 @@
 import { union, object, string, optional, boolean, enums } from "superstruct";
 import { TIMESTAMP_RENDERING_FORMATS } from "../../components/types";
-import { actionConfigStruct } from "./action-struct";
+import {
+  actionConfigStruct,
+  actionConfigStructConfirmation,
+} from "./action-struct";
 
 export const entitiesConfigStruct = union([
   object({
@@ -14,6 +17,7 @@ export const entitiesConfigStruct = union([
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),
+    confirmation: optional(actionConfigStructConfirmation),
   }),
   string(),
 ]);

--- a/src/panels/lovelace/entity-rows/hui-button-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-button-entity-row.ts
@@ -14,6 +14,7 @@ import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { ActionRowConfig, LovelaceRow } from "./types";
+import { confirmAction } from "../common/confirm-action";
 
 @customElement("hui-button-entity-row")
 class HuiButtonEntityRow extends LitElement implements LovelaceRow {
@@ -69,11 +70,21 @@ class HuiButtonEntityRow extends LitElement implements LovelaceRow {
     `;
   }
 
-  private _pressButton(ev): void {
+  private async _pressButton(ev): Promise<void> {
     ev.stopPropagation();
-    this.hass.callService("button", "press", {
-      entity_id: this._config!.entity,
-    });
+    if (
+      !this._config?.confirmation ||
+      (await confirmAction(
+        this,
+        this.hass,
+        this._config.confirmation,
+        this.hass.localize("ui.card.button.press")
+      ))
+    ) {
+      this.hass.callService("button", "press", {
+        entity_id: this._config!.entity,
+      });
+    }
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-input-button-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-button-entity-row.ts
@@ -14,6 +14,7 @@ import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { ActionRowConfig, LovelaceRow } from "./types";
+import { confirmAction } from "../common/confirm-action";
 
 @customElement("hui-input-button-entity-row")
 class HuiInputButtonEntityRow extends LitElement implements LovelaceRow {
@@ -69,11 +70,21 @@ class HuiInputButtonEntityRow extends LitElement implements LovelaceRow {
     `;
   }
 
-  private _pressButton(ev): void {
+  private async _pressButton(ev): Promise<void> {
     ev.stopPropagation();
-    this.hass.callService("input_button", "press", {
-      entity_id: this._config!.entity,
-    });
+    if (
+      !this._config?.confirmation ||
+      (await confirmAction(
+        this,
+        this.hass,
+        this._config.confirmation,
+        this.hass.localize("ui.card.button.press")
+      ))
+    ) {
+      this.hass.callService("input_button", "press", {
+        entity_id: this._config!.entity,
+      });
+    }
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
@@ -16,6 +16,7 @@ import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { ActionRowConfig, LovelaceRow } from "./types";
+import { confirmAction } from "../common/confirm-action";
 
 @customElement("hui-scene-entity-row")
 class HuiSceneEntityRow extends LitElement implements LovelaceRow {
@@ -76,9 +77,19 @@ class HuiSceneEntityRow extends LitElement implements LovelaceRow {
     `;
   }
 
-  private _callService(ev: Event): void {
+  private async _callService(ev: Event): Promise<void> {
     ev.stopPropagation();
-    activateScene(this.hass, this._config!.entity);
+    if (
+      !this._config?.confirmation ||
+      (await confirmAction(
+        this,
+        this.hass,
+        this._config.confirmation,
+        this._config.action_name || this.hass.localize("ui.card.scene.activate")
+      ))
+    ) {
+      activateScene(this.hass, this._config!.entity);
+    }
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
@@ -16,6 +16,7 @@ import "../components/hui-generic-entity-row";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { ActionRowConfig, LovelaceRow } from "./types";
 import { showMoreInfoDialog } from "../../../dialogs/more-info/show-ha-more-info-dialog";
+import { confirmAction } from "../common/confirm-action";
 
 @customElement("hui-script-entity-row")
 class HuiScriptEntityRow extends LitElement implements LovelaceRow {
@@ -91,12 +92,20 @@ class HuiScriptEntityRow extends LitElement implements LovelaceRow {
     this._callService("turn_off");
   }
 
-  private _runScript(ev): void {
+  private async _runScript(ev): Promise<void> {
     ev.stopPropagation();
 
     if (hasScriptFields(this.hass!, this._config!.entity)) {
       showMoreInfoDialog(this, { entityId: this._config!.entity });
-    } else {
+    } else if (
+      !this._config?.confirmation ||
+      (await confirmAction(
+        this,
+        this.hass!,
+        this._config.confirmation,
+        this._config.action_name || this.hass!.localize("ui.card.script.run")
+      ))
+    ) {
       this._callService("turn_on");
     }
   }

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -1,4 +1,7 @@
-import type { ActionConfig } from "../../../data/lovelace/config/action";
+import type {
+  ActionConfig,
+  ConfirmationRestrictionConfig,
+} from "../../../data/lovelace/config/action";
 import type { HomeAssistant } from "../../../types";
 import type { LegacyStateFilter } from "../common/evaluate-filter";
 import type { Condition } from "../common/validate-condition";
@@ -11,7 +14,12 @@ export interface EntityConfig {
   icon?: string;
   image?: string;
 }
-export interface ActionRowConfig extends EntityConfig {
+
+export interface ConfirmableRowConfig extends EntityConfig {
+  confirmation?: ConfirmationRestrictionConfig;
+}
+
+export interface ActionRowConfig extends ConfirmableRowConfig {
   action_name?: string;
 }
 export interface EntityFilterEntityConfig extends EntityConfig {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This change proposes to start implementing some of the suggestions of https://github.com/home-assistant/frontend/discussions/8905.

It adds an option to add a confirmation directly to an entity-row of entities card, outside of a tap-action, e.g.:

```
  - entity: button.push
    confirmation: true
```    

This confirmation would then restrict interactions with special interactive elements of entity rows other than which is controlled by tap-action/hold-action. For example this will add confirmation to the `Press` button on button entity type rows. 

This PR is just a partial implementation, and starts with supporting confirmations for the "single button" type entity rows only:
- `button` / `input_button`
- `lock`
- `scene`
- `script`

If this is favorably approved, I may then extend to adding this support for `cover` (confirmation on open/close/tilt actions), and may finally implement the suggestion from the linked discussion for `toggle`, which is that toggles with a confirmation be replaced with a labelled button.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a confirmation mechanism for user actions across multiple entity rows, enhancing interaction and preventing accidental executions.
  - Added a new configuration option for confirmation within entity rows.

- **Bug Fixes**
  - Updated button press methods to include asynchronous confirmation handling, improving the overall robustness of actions.

- **Documentation**
  - Updated code comments and interface definitions to reflect new confirmation features and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->