### PR TITLE
Only show webrtc if it has video

### DIFF
--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -102,7 +102,9 @@ export class HaCameraStream extends LitElement {
           .entityid=${this.stateObj.entity_id}
           .posterUrl=${this._posterUrl}
           @streams=${this._handleHlsStreams}
-          class=${!this._streamType && this._webRtcStreams ? "hidden" : ""}
+          class=${!this._streamType && this._webRtcStreams?.hasVideo
+            ? "hidden"
+            : ""}
         ></ha-hls-player>`
       : nothing}
     ${this._streamType === STREAM_TYPE_WEB_RTC ||


### PR DESCRIPTION



## Proposed change

We would show webrtc if it was loaded before hls, but we also did this when it would error when not supported.

We now only show webrtc if it has a video stream.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
