### PR TITLE
ZWaveJS: Color Switch support fot the expert UI

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-color-switch.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-color-switch.ts
@@ -67,7 +67,13 @@ class ZWaveJSCapabilityColorSwitch extends LitElement {
   }
 
   private _transformOptions(color: number) {
-    return () => color;
+    return (opts: Record<string, any>, control: string) =>
+      control === "startLevelChange"
+        ? {
+            ...opts,
+            colorComponent: color,
+          }
+        : color;
   }
 }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-color-switch.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-color-switch.ts
@@ -45,7 +45,7 @@ class ZWaveJSCapabilityColorSwitch extends LitElement {
             .endpoint=${this.endpoint}
             .command_class=${this.command_class}
             .version=${this.version}
-            .extra_cc_options=${{ colorComponent: color }}
+            .transform_options=${this._transformOptions(color)}
           ></zwave_js-capability-control-multilevel_switch>`
     );
   }
@@ -64,6 +64,10 @@ class ZWaveJSCapabilityColorSwitch extends LitElement {
     } catch (error) {
       this._error = extractApiErrorMessage(error);
     }
+  }
+
+  private _transformOptions(color: number) {
+    return () => color;
   }
 }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-color-switch.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-color-switch.ts
@@ -45,7 +45,7 @@ class ZWaveJSCapabilityColorSwitch extends LitElement {
             .endpoint=${this.endpoint}
             .command_class=${this.command_class}
             .version=${this.version}
-            .extra_cc_options=${{ colorComponent: "red" }}
+            .extra_cc_options=${{ colorComponent: color }}
           ></zwave_js-capability-control-multilevel_switch>`
     );
   }

--- a/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-multilevel-switch.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-multilevel-switch.ts
@@ -28,6 +28,8 @@ class ZWaveJSCapabilityMultiLevelSwitch extends LitElement {
 
   @property({ type: Number }) public version!: number;
 
+  @property({ attribute: false }) public extra_cc_options?: Record<string, any>;
+
   @state() private _error?: string;
 
   protected render() {
@@ -109,6 +111,13 @@ class ZWaveJSCapabilityMultiLevelSwitch extends LitElement {
       (this.shadowRoot!.getElementById("start_level") as HaTextField).value
     );
 
+    const options = {
+      direction,
+      ignoreStartLevel,
+      startLevel,
+      ...this.extra_cc_options,
+    };
+
     try {
       button.actionSuccess();
       await invokeZWaveCCApi(
@@ -117,7 +126,7 @@ class ZWaveJSCapabilityMultiLevelSwitch extends LitElement {
         this.command_class,
         this.endpoint,
         control,
-        [{ direction, ignoreStartLevel, startLevel }],
+        [options],
         true
       );
     } catch (err) {

--- a/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-multilevel-switch.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-multilevel-switch.ts
@@ -29,7 +29,8 @@ class ZWaveJSCapabilityMultiLevelSwitch extends LitElement {
   @property({ type: Number }) public version!: number;
 
   @property({ attribute: false }) public transform_options?: (
-    opts: Record<string, any>
+    opts: Record<string, any>,
+    control: string
   ) => unknown;
 
   @state() private _error?: string;
@@ -127,7 +128,11 @@ class ZWaveJSCapabilityMultiLevelSwitch extends LitElement {
         this.command_class,
         this.endpoint,
         control,
-        [this.transform_options ? this.transform_options(options) : options],
+        [
+          this.transform_options
+            ? this.transform_options(options, control)
+            : options,
+        ],
         true
       );
     } catch (err) {

--- a/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-multilevel-switch.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/capability-controls/zwave_js-capability-control-multilevel-switch.ts
@@ -28,7 +28,9 @@ class ZWaveJSCapabilityMultiLevelSwitch extends LitElement {
 
   @property({ type: Number }) public version!: number;
 
-  @property({ attribute: false }) public extra_cc_options?: Record<string, any>;
+  @property({ attribute: false }) public transform_options?: (
+    opts: Record<string, any>
+  ) => unknown;
 
   @state() private _error?: string;
 
@@ -115,7 +117,6 @@ class ZWaveJSCapabilityMultiLevelSwitch extends LitElement {
       direction,
       ignoreStartLevel,
       startLevel,
-      ...this.extra_cc_options,
     };
 
     try {
@@ -126,7 +127,7 @@ class ZWaveJSCapabilityMultiLevelSwitch extends LitElement {
         this.command_class,
         this.endpoint,
         control,
-        [options],
+        [this.transform_options ? this.transform_options(options) : options],
         true
       );
     } catch (err) {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-installer.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-installer.ts
@@ -22,10 +22,12 @@ import type { HomeAssistant, Route } from "../../../../../types";
 import "../../../ha-config-section";
 import "./capability-controls/zwave_js-capability-control-multilevel-switch";
 import "./capability-controls/zwave_js-capability-control-thermostat-setback";
+import "./capability-controls/zwave_js-capability-control-color-switch";
 
 const CAPABILITY_CONTROLS = {
   38: "multilevel_switch",
   71: "thermostat_setback",
+  51: "color_switch",
 };
 
 @customElement("zwave_js-node-installer")

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5170,6 +5170,9 @@
                 "start_transition": "Start transition",
                 "stop_transition": "Stop transition",
                 "control_failed": "Failed to control transition. {error}"
+              },
+              "color_switch": {
+                "color_component": "Color component"
               }
             }
           }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
For https://github.com/zwave-js/certification-backlog/issues/18
Basically a MultiLevel switch for each supported color channel

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [#](https://github.com/zwave-js/certification-backlog/issues/18)
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
