### PR TITLE
Enable auto-scroll for drag and drop

### DIFF
--- a/src/components/ha-sortable.ts
+++ b/src/components/ha-sortable.ts
@@ -135,6 +135,10 @@ export class HaSortable extends LitElement {
     const Sortable = (await import("../resources/sortable")).default;
 
     const options: SortableInstance.Options = {
+      scroll: true,
+      // Force the autoscroll fallback because it works better than the native one
+      forceAutoScrollFallback: true,
+      scrollSpeed: 20,
       animation: 150,
       ...this.options,
       onChoose: this._handleChoose,

--- a/src/resources/sortable.ts
+++ b/src/resources/sortable.ts
@@ -1,10 +1,11 @@
 import type Sortable from "sortablejs";
 import SortableCore, {
-  OnSpill,
   AutoScroll,
+  OnSpill,
 } from "sortablejs/modular/sortable.core.esm";
 
-SortableCore.mount(OnSpill, new AutoScroll());
+SortableCore.mount(OnSpill);
+SortableCore.mount(new AutoScroll());
 
 export default SortableCore as typeof Sortable;
 


### PR DESCRIPTION
## Proposed change

Enable autoscroll for drag and drop (e.g. dashboard, automation). Is wasn't really enabled because we misused the mount function 🤦‍♂️

I tested on iOS, Android, macOS and windows with multiple browsers.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
