### PR TITLE
Show YAML parsing errors in automation editor

### DIFF
--- a/src/components/ha-yaml-editor.ts
+++ b/src/components/ha-yaml-editor.ts
@@ -130,6 +130,7 @@ export class HaYamlEditor extends LitElement {
     this._yaml = ev.detail.value;
     let parsed;
     let isValid = true;
+    let errorMsg;
 
     if (this._yaml) {
       try {
@@ -137,6 +138,7 @@ export class HaYamlEditor extends LitElement {
       } catch (err: any) {
         // Invalid YAML
         isValid = false;
+        errorMsg = `${this.hass.localize("ui.components.yaml-editor.error", { reason: err.reason })}${err.mark ? ` (${this.hass.localize("ui.components.yaml-editor.error_location", { line: err.mark.line + 1, column: err.mark.column + 1 })})` : ""}`;
       }
     } else {
       parsed = {};
@@ -145,7 +147,11 @@ export class HaYamlEditor extends LitElement {
     this.value = parsed;
     this.isValid = isValid;
 
-    fireEvent(this, "value-changed", { value: parsed, isValid } as any);
+    fireEvent(this, "value-changed", {
+      value: parsed,
+      isValid,
+      errorMsg,
+    } as any);
   }
 
   get yaml() {

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -423,9 +423,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
         </div>
         <ha-fab
           slot="fab"
-          class=${classMap({
-            dirty: !this._readOnly && this._dirty,
-          })}
+          class=${classMap({ dirty: !this._readOnly && this._dirty })}
           .label=${this.hass.localize("ui.panel.config.automation.editor.save")}
           extended
           @click=${this._saveAutomation}

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -424,7 +424,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
         <ha-fab
           slot="fab"
           class=${classMap({
-            dirty: !this._readOnly && (this._dirty || !!this._yamlErrors),
+            dirty: !this._readOnly && this._dirty,
           })}
           .label=${this.hass.localize("ui.panel.config.automation.editor.save")}
           extended
@@ -633,6 +633,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
 
   private _yamlChanged(ev: CustomEvent) {
     ev.stopPropagation();
+    this._dirty = true;
     if (!ev.detail.isValid) {
       this._yamlErrors = ev.detail.errorMsg;
       return;
@@ -643,7 +644,6 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
       ...normalizeAutomationConfig(ev.detail.value),
     };
     this._errors = undefined;
-    this._dirty = true;
   }
 
   private async confirmUnsavedChanged(): Promise<boolean> {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1029,7 +1029,9 @@
         "temperature_down": "Decrease temperature"
       },
       "yaml-editor": {
-        "copy_to_clipboard": "[%key:ui::panel::config::automation::editor::copy_to_clipboard%]"
+        "copy_to_clipboard": "[%key:ui::panel::config::automation::editor::copy_to_clipboard%]",
+        "error": "Error in parsing YAML: {reason}",
+        "error_location": "line: {line}, column: {column}"
       },
       "state-content-picker": {
         "state": "State",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When using yaml mode of the automation editor, dealing with yaml syntax errors is very difficult. 

I was assisting a user who shared a large complex automation that was throwing bizarre errors. It turns out he had a yaml syntax error, and in any event when yaml is invalid, and you click save, it attemps to submit not what is entered in the code box, but the _last valid yaml_ that was entered in the code box. So it was trying to validate something completely different from what the user had entered. 

Our yaml parser gives nice error messages when yaml is invalid, but we currently throw them away without showing the user. 

This PR exposes these YAML errors to the user in a toast when the save button is clicked, to get better feedback on issues, e.g.

![image](https://github.com/user-attachments/assets/ecf66227-e7a8-4a9b-845a-3df3181256ba)

Before this change, clicking save reported something stupid like "key not provided @ data['actions']", which is nonsense, as the yaml editor clearly had an actions key. 

Or sometimes the save FAB would just disappear altogether, as yaml with a syntax error was not recognized as correctly dirtying the form.

Even better would be to find a way to leverage the snippet provided in the yaml exception, since that is even clearer about the error, but that doesn't work well in a toast as it is a single line and not monospaced. We could maybe use this if we popped up a dialog or something, but I won't go this far for now.

![image](https://github.com/user-attachments/assets/e9ee7e4c-292c-47ef-b827-6bef70c55907)




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
