### PR TITLE
Fix typo in Czech language for blank before percent

### DIFF
--- a/src/common/translations/blank_before_percent.ts
+++ b/src/common/translations/blank_before_percent.ts
@@ -5,7 +5,7 @@ export const blankBeforePercent = (
   localeOptions: FrontendLocaleData
 ): string => {
   switch (localeOptions.language) {
-    case "cz":
+    case "cs":
     case "de":
     case "fi":
     case "fr":


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The correct ISO 639 language code for Czech is 'cs' (not 'cz', which is the country code for Czechia).
The 'cz' language code does not exists.

[List of ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes)

Currently, percent formatting for Czech language doesn't work as expected: there is no space added between the number and the percent symbol.

![image](https://github.com/user-attachments/assets/16f3a5ea-aaac-4bcd-91b3-534ed02dbb11)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
