### PR TITLE
Z-Wave JS: Fix validation/parsing for custom config param UI

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
@@ -117,21 +117,32 @@ class ZWaveJSCustomParam extends LitElement {
     `;
   }
 
+  private _tryParseNumber(value: string): number | undefined {
+    if (!value) return;
+    const parsed = Number(value);
+    if (Number.isNaN(parsed)) return;
+    // eslint-disable-next-line consistent-return -- not sure why eslint expects no return here
+    return parsed;
+  }
+
   private _customParamNumberChanged(ev: Event) {
-    this._customParamNumber =
-      Number((ev.target as HTMLInputElement).value) || undefined;
+    this._customParamNumber = this._tryParseNumber(
+      (ev.target as HTMLInputElement).value
+    );
   }
 
   private _customValueSizeChanged(ev: Event) {
-    this._valueSize = Number((ev.target as HTMLSelectElement).value) || 1;
+    this._valueSize =
+      this._tryParseNumber((ev.target as HTMLSelectElement).value) ?? 1;
   }
 
   private _customValueChanged(ev: Event) {
-    this._value = Number((ev.target as HTMLInputElement).value) || undefined;
+    this._value = this._tryParseNumber((ev.target as HTMLInputElement).value);
   }
 
   private _customValueFormatChanged(ev: Event) {
-    this._valueFormat = Number((ev.target as HTMLSelectElement).value) || 0;
+    this._valueFormat =
+      this._tryParseNumber((ev.target as HTMLSelectElement).value) ?? 0;
   }
 
   private async _getCustomConfigValue() {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
@@ -118,10 +118,9 @@ class ZWaveJSCustomParam extends LitElement {
   }
 
   private _tryParseNumber(value: string): number | undefined {
-    if (!value) return;
+    if (!value) return undefined;
     const parsed = Number(value);
-    if (Number.isNaN(parsed)) return;
-    // eslint-disable-next-line consistent-return -- not sure why eslint expects no return here
+    if (Number.isNaN(parsed)) return undefined;
     return parsed;
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes the validation part of https://github.com/zwave-js/certification-backlog/issues/31#issuecomment-2470437479


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
