### PR TITLE
Remove display of 'Current state' in ha-card-condition-state

### DIFF
--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
@@ -4,6 +4,7 @@ import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { assert, literal, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../../common/dom/fire_event";
+import { getStates } from "../../../../../common/entity/get_states";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import "../../../../../components/ha-form/ha-form";
 import type {
@@ -152,7 +153,7 @@ export class HaCardConditionState extends LitElement {
             "ui.components.entity.entity-state-picker.state"
           )} (${this.hass.localize(
             "ui.panel.lovelace.editor.condition-editor.condition.state.current_state"
-          )}: ${this.hass.formatEntityState(entity)})`;
+          )}: ${getStates(entity).includes(entity.state) ? this.hass.formatEntityState(entity) : entity.state})`;
         }
         return `${this.hass.localize(
           "ui.components.entity.entity-state-picker.state"

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
@@ -4,7 +4,6 @@ import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { assert, literal, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import { getStates } from "../../../../../common/entity/get_states";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import "../../../../../components/ha-form/ha-form";
 import type {
@@ -141,24 +140,13 @@ export class HaCardConditionState extends LitElement {
   private _computeLabelCallback = (
     schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string => {
-    const entity = this.condition.entity
-      ? this.hass.states[this.condition.entity]
-      : undefined;
     switch (schema.name) {
       case "entity":
         return this.hass.localize("ui.components.entity.entity-picker.entity");
       case "state":
-        if (entity) {
-          return `${this.hass.localize(
-            "ui.components.entity.entity-state-picker.state"
-          )} (${this.hass.localize(
-            "ui.panel.lovelace.editor.condition-editor.condition.state.current_state"
-          )}: ${getStates(entity).includes(entity.state) ? this.hass.formatEntityState(entity) : entity.state})`;
-        }
-        return `${this.hass.localize(
+        return this.hass.localize(
           "ui.components.entity.entity-state-picker.state"
-        )}`;
-
+        );
       default:
         return "";
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5987,8 +5987,7 @@
               "state": {
                 "label": "Entity state",
                 "state_equal": "State is equal to",
-                "state_not_equal": "State is not equal to",
-                "current_state": "current"
+                "state_not_equal": "State is not equal to"
               },
               "user": {
                 "label": "User"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Changed PR, see comment thread. 

~~I see this question come up a lot in community support. User makes a visibility state condition, enters the state exactly matching the current state, and the current state check fails.~~

![image](https://github.com/user-attachments/assets/0076d85e-3820-4846-a72c-c2c5a1e5902c)

~~This happens when using an entity which has a translated state, but the translation is not really known to the frontend (as it might not be an enum). So if you type the translated string in the textbox, then the comparison ends up comparing the untranslated state to the translated state, and the check fails.~~

~~I suggest to change this so that the translated state is only shown here for `current:` if frontend knows the translation map (e.g. if the value is selectable in the dropdown). If it's just a state translation for some random sensor and we don't know the mapping, then just show the current state as the raw untranslated state. Then when the user types that string, the check will pass.~~




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
