### PR TITLE
Fixes #17769, #22503: Improved subscription handling

### DIFF
--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -223,17 +223,17 @@ export class HaLogbook extends LitElement {
     }
   }
 
-  public async connectedCallback() {
+  public connectedCallback() {
     super.connectedCallback();
     if (this.hasUpdated) {
       // Ensure clean state before subscribing
-      await this._subscribeLogbookPeriod(this._calculateLogbookPeriod());
+      this._subscribeLogbookPeriod(this._calculateLogbookPeriod());
     }
   }
 
-  public async disconnectedCallback() {
+  public disconnectedCallback() {
     super.disconnectedCallback();
-    await this._unsubscribeSetLoading();
+    this._unsubscribeSetLoading();
   }
 
   /** Unsubscribe because we are unloading

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -308,8 +308,8 @@ export class HaLogbook extends LitElement {
         this.entityIds,
         this.deviceIds
       ).catch((err) => {
-          this._subscribed = undefined;
-          this._error = err;
+        this._subscribed = undefined;
+        this._error = err;
       });
     });
     return true;


### PR DESCRIPTION
## Proposed change
- Prevent multiple active subscriptions
- Ensure a clean state when the component reconnects
- Checking subscription status before processing

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #17769 #22503 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
