### PR TITLE
Better explain the "Push notification" option in the browser settings

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6748,8 +6748,8 @@
           "description": "Should we close the connection to the server after being hidden for 5 minutes?"
         },
         "push_notifications": {
-          "header": "Push notifications",
-          "description": "Send notifications to this device.",
+          "header": "Receive notifications",
+          "description": "Enable HTML5 browser notifications on this device.",
           "error_load_platform": "Configure notify.html5.",
           "error_use_https": "Requires SSL enabled for frontend.",
           "push_notifications": "Push notifications",


### PR DESCRIPTION
HTML5 browser notifications should be explained from the user perspective as receiving notification on his or her device.

Currently the setting is seen from the server perspective and while very technical does not contain HTML5 which the corresponding actions use.

Users are used to being asked: "Would you like to receive notifications on this device?"
This setting should use a similar way of explaining its function.

The PR fixes this by rewording the headline and the explanation.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

By switching to "receiving notification" we improve this in three ways:

1. The non-techie end-user understands that she needs to turn on reception by flipping the switch.
(Don't forget that we talk about the different members of the household and their computers here)
2. It is inherently clear that this involves granting notification permissions within the browser.
(People are used to that from other websites and mobile apps, at least a bit)
3. By including "HTML5" in that explanation the user is guided where to find the corresponding actions in automations.
(This helps beginners in trying out if it really works)

Note that in the mobile apps this setting is hidden, so no confusion there.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22662 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
