### PR TITLE
Use consistent name "Entity search" for that part of "Quick Search"

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7527,7 +7527,7 @@
     },
     "tips": {
       "key_c_hint": "Press 'c' on any page to open the command dialog",
-      "key_e_hint": "Press 'e' on any page to open the Entity search dialog",
+      "key_e_hint": "Press 'e' on any page to open the entity search dialog",
       "key_m_hint": "Press 'm' on any page to get the My Home Assistant link"
     }
   },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1195,7 +1195,7 @@
             "addon_info": "{addon} Info"
           }
         },
-        "filter_placeholder": "Entity filter",
+        "filter_placeholder": "Search entities",
         "title": "Quick search",
         "key_c_hint": "Press 'c' on any page to open the search bar",
         "nothing_found": "Nothing found!"
@@ -5744,7 +5744,7 @@
         "menu": {
           "configure_ui": "Edit dashboard",
           "help": "Help",
-          "search": "Search",
+          "search": "Entity search",
           "assist": "Assist",
           "reload_resources": "Reload resources",
           "exit_edit_mode": "Done",
@@ -7527,7 +7527,7 @@
     },
     "tips": {
       "key_c_hint": "Press 'c' on any page to open the command dialog",
-      "key_e_hint": "Press 'e' on any page to open the entity search dialog",
+      "key_e_hint": "Press 'e' on any page to open the Entity search dialog",
       "key_m_hint": "Press 'm' on any page to get the My Home Assistant link"
     }
   },


### PR DESCRIPTION
Currently the Entity search dialog displays "Entity filter" in its search field, while the "key_e_hint" calls it "entity search".

This needs to be made consistent with all other Search fields by using "Search entities" instead.

Also this removes the conflict with the "Entity filter" card on the Dashboard which is a completely different thing.

For consistency the tooltip to open that dialog should be changed to "Entity search" instead of just "Search".

And finally, as "Entity search" turns into a name the 'key_e_hint' should reflect that, too.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Change the "Search" tooltip to "Entity search" to match "Quick search" for commands in other contexts.

Change the 'key_e_hint' to "Entity search", matching "My Home Assistant" for the 'key_m_hint'

Finally change the label in the search field to "Search entities" to remove the name conflict with the "Entity filter" card.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22547 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
