### PR TITLE
Fix two strings for Settings > Tags

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2215,7 +2215,7 @@
           "write": "Write",
           "edit": "Edit",
           "never_scanned": "Never scanned",
-          "create_automation": "Create automation with tag",
+          "create_automation": "Create automation with this tag",
           "confirm_delete_title": "Delete tag?",
           "confirm_delete": "Are you sure you want to delete tag {tag}?",
           "automation_title": "Tag {name} is scanned",
@@ -2237,7 +2237,7 @@
             "create": "Create",
             "create_and_write": "Create and write",
             "required_error_msg": "[%key:ui::panel::config::zone::detail::required_error_msg%]",
-            "usage": "A tag can trigger an automation when scanned, you can use NFC tags, QR codes or any other kind of tag. Use our {companion_link} to write this tag to a programmable NFC tag or create a QR code below.",
+            "usage": "A tag can trigger an automation when scanned, you can use NFC tags, QR codes or any other kind of tag. Use our {companion_link} to write this tag to a programmable NFC tag or copy and print the QR code below.",
             "companion_apps": "companion apps"
           }
         },


### PR DESCRIPTION
In Settings > Tags the explanation for the QR code does not make sense right now.
It says "… create a QR code below" where the code is already displayed.

And the tooltip for the button 'Create automation with tag' missing a 'this' to refer to the one the user is pointing at.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Change the QR code explanation to " … or copy and print the QR code below."
Add a "this" to the 'Create automation' tooltip.

The latter also makes it much easier to write a correct translation without knowing the context.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22304 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
