### PR TITLE
Change "Elevation" to "Elevation above sea level" for clarity

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2439,7 +2439,7 @@
                 "location_name": "Name",
                 "latitude": "Latitude",
                 "longitude": "Longitude",
-                "elevation": "Elevation",
+                "elevation": "Elevation above sea level",
                 "elevation_meters": "meters",
                 "time_zone": "Time zone",
                 "language": "Language",


### PR DESCRIPTION
In Settings > System > General the user can provide the elevation of the home location.
This means the elevation above sea level in meters, so this should be written here.

Judging from discussions on the net, many users don't understand it right now.
Probably even more without misleading translations.

Also the term "Elevation" is used in the Sun integration as well, but there it's the sun's angle above or below the horizon, something completely different.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Change "Elevation" to  "Elevation above sea level".

In German this is "Höhe über NN" ("Altitude above Normal Null"), BTW.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22508 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
