### PR TITLE
Improve explanation of response variables

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3415,8 +3415,8 @@
                 "service": {
                   "label": "Perform action",
                   "response_variable": "Response variable",
-                  "has_optional_response": "This action can return a response, if you want to use the response, enter the name for a variable the response will be saved in",
-                  "has_response": "This action returns a response, enter the name for a variable the response will be saved in",
+                  "has_optional_response": "This action can return a response, if you want to use the response, enter the name for a variable the response will be saved in.",
+                  "has_response": "This action returns a response, enter the name for a variable the response will be saved in.",
                   "description": {
                     "picker": "Previously known as call service.",
                     "service_based_on_template": "Perform an action based on a template on {targets}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3415,8 +3415,8 @@
                 "service": {
                   "label": "Perform action",
                   "response_variable": "Response variable",
-                  "has_optional_response": "This action can return a response, if you want to use the response, enter the name of a variable the response will be saved in",
-                  "has_response": "This action returns a response, enter the name of a variable the response will be saved in",
+                  "has_optional_response": "This action can return a response, if you want to use the response, enter the name for a variable the response will be saved in",
+                  "has_response": "This action returns a response, enter the name for a variable the response will be saved in",
                   "description": {
                     "picker": "Previously known as call service.",
                     "service_based_on_template": "Perform an action based on a template on {targets}",


### PR DESCRIPTION
When an action does return a result the user can save this in a variable that can be used in the next actions in the sequence.

That variable is created by simply naming it in the action.
This should be made clearer in the two strings that describe this option.

By using "… name _for_ a variable …" becomes inherently clear that this variable will be created by the action.

_I'm not sure if it is that obvious in English, but in German "… der Name einer Variable …" implies that it already exists under that name, while " … der Name **für** eine Variable …" implies that it will be created with that specified name. That's where the main motivation for the PR comes from._

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Change "of" to "for a variable" in both strings.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22824 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
