### PR TITLE
Dev Tools: Replace "Current entities" with "Current entity states"

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7184,7 +7184,7 @@
             "attributes": "Attributes",
             "state_attributes": "State attributes (YAML, optional)",
             "set_state": "Set state",
-            "current_entities": "Current entities",
+            "current_entities": "Current entity states",
             "filter_entities": "Filter entities",
             "filter_states": "Filter states",
             "filter_attributes": "Filter attributes",


### PR DESCRIPTION
Under the States tab of the Developer tools the big headline is "Current entities".

This needs to be "Current entity states" instead as it's the current states (and attributes) that this tab is about.

In the linked bug report I also suggested the even more precise "Current entity states and attributes" but that becomes too long and will consume two lines of the big font headline on mobile. Attributes are optional so they can be omitted in the headline.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Replace "Current entities" with "Current entity states".

This also helps in creating accurate translations.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22631 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
