### PR TITLE
Change "Add" to "Create" for Labels and Zones following HA Design guidelines

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2109,7 +2109,7 @@
             "icon": "Icon",
             "color": "Color"
           },
-          "add_label": "Add label",
+          "add_label": "Create label",
           "manage_labels": "Manage labels",
           "no_labels": "You don't have any labels",
           "introduction": "Labels can help you organize your areas, devices and entities. They can be used to filter in the UI, or use them as a target in automations.",
@@ -4347,8 +4347,8 @@
           "caption": "Zones",
           "description": "Manage the zones you want to track people in",
           "introduction": "Zones allow you to specify certain regions on Earth. When a person is within a zone, the state will take the name from the zone. Zones can also be used as a trigger or condition inside automation setups.",
-          "no_zones_created_yet": "Looks like you have not added any zones yet.",
-          "create_zone": "Add zone",
+          "no_zones_created_yet": "Looks like you have not created any zones yet.",
+          "create_zone": "Create zone",
           "add_zone": "Add zone",
           "edit_zone": "Edit zone",
           "edit_home": "Edit home",
@@ -4368,7 +4368,7 @@
             "passive_note": "Passive zones are hidden in the frontend and are not used as location for device trackers. This is useful if you just want to use it for automations.",
             "required_error_msg": "This field is required",
             "delete": "Delete",
-            "create": "Add",
+            "create": "Create",
             "update": "Update"
           },
           "core_location_dialog": "Home Assistant location"


### PR DESCRIPTION
Following up on the [previous PR](https://github.com/home-assistant/frontend/pull/22922#event-15371983451) for the 'Automations & Scenes' section this PR implements the same necessary fixes according to the [Home Assistant Design guidelines](https://design.home-assistant.io/#Text/remove-delete-add-create) regarding the use of "Create" vs. "Add".

Under Areas in the 'Areas, labels and zones' part of settings we already have the action buttons:

- Create floor
- Create area 

But for Labels and Zones there are still the inconsistent buttons:

- Add label
- Add zone

While "Add" should only be used for existing entities, both labels and zones are "created" in HA by the user.

This PR addresses that to make all four action buttons and some related strings consistent in this part of settings.

Note that for a tracked person there is an option to create a zone based on the current location.
That is already correct using:

https://github.com/home-assistant/frontend/blob/4e63eacb79ce492e749c26ba95201e55dc9140d0/src/translations/en.json#L1289-L1290

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Change "Add label" to "Create label".
Change "Add zone" to "Create zone".
Change the "Add" button in the 'New zone' dialog to "Create".

Fix the "Looks like you have not added any zones yet." that is shown when the tab is empty.

**Note that there is one more "add_zone": "Add zone" key that I haven't touched here.**

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
