### PR TITLE
Restrict generate backup content for core backup

### DIFF
--- a/src/data/backup.ts
+++ b/src/data/backup.ts
@@ -45,10 +45,10 @@ export interface BackupAgentsInfo {
 export type GenerateBackupParams = {
   agent_ids: string[];
   include_addons?: string[];
-  include_all_addons: boolean;
-  include_database: boolean;
+  include_all_addons?: boolean;
+  include_database?: boolean;
   include_folders?: string[];
-  include_homeassistant: boolean;
+  include_homeassistant?: boolean;
   name?: string;
   password?: string;
 };

--- a/src/panels/config/backup/ha-config-backup-dashboard.ts
+++ b/src/panels/config/backup/ha-config-backup-dashboard.ts
@@ -46,6 +46,7 @@ import { fileDownload } from "../../../util/file_download";
 import "./components/ha-backup-summary-card";
 import { showGenerateBackupDialog } from "./dialogs/show-dialog-generate-backup";
 import { showNewBackupDialog } from "./dialogs/show-dialog-new-backup";
+import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 
 @customElement("ha-config-backup-dashboard")
 class HaConfigBackupDashboard extends SubscribeMixin(LitElement) {
@@ -284,12 +285,15 @@ class HaConfigBackupDashboard extends SubscribeMixin(LitElement) {
       // Todo : Use default config instead of hardcoded one
       const { agents } = await fetchBackupAgentsInfo(this.hass);
 
-      this._generateBackup({
+      const params: GenerateBackupParams = {
         agent_ids: agents.map((agent) => agent.agent_id),
         include_homeassistant: true,
         include_database: true,
-        include_all_addons: false,
-      });
+      };
+      if (isComponentLoaded(this.hass, "hassio")) {
+        params.include_all_addons = true;
+      }
+      this._generateBackup(params);
     }
   }
 


### PR DESCRIPTION
## Proposed change

- Home Assistant settings is mandatory for core backups
- Exclude folder and addons for core backups
- Do not display folder and addons for core backups

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
