### PR TITLE
Force enable home assistant settings when history is selected in backup

### DIFF
--- a/src/panels/config/backup/dialogs/dialog-generate-backup.ts
+++ b/src/panels/config/backup/dialogs/dialog-generate-backup.ts
@@ -204,7 +204,7 @@ class DialogGenerateBackup extends LitElement implements HassDialog {
           name="homeassistant"
           @change=${this._switchChanged}
           .checked=${this._formData.homeassistant}
-          .disabled=${!isHassio}
+          .disabled=${!isHassio || this._formData.database}
         ></ha-switch>
       </ha-settings-row>
       <ha-settings-row>
@@ -365,6 +365,13 @@ class DialogGenerateBackup extends LitElement implements HassDialog {
       ...this._formData!,
       [_switch.id]: _switch.checked,
     };
+    // If we enable database, we also enable homeassistant
+    if (_switch.id === "database" && _switch.checked) {
+      this._formData = {
+        ...this._formData,
+        homeassistant: true,
+      };
+    }
   }
 
   private _nameChanged(ev) {
@@ -396,7 +403,8 @@ class DialogGenerateBackup extends LitElement implements HassDialog {
     const params: GenerateBackupParams = {
       name,
       agent_ids: agents_mode === "all" ? ALL_AGENT_IDS : agent_ids,
-      include_homeassistant: homeassistant,
+      // We always include homeassistant if we include database
+      include_homeassistant: homeassistant || database,
       include_database: database,
     };
 


### PR DESCRIPTION
## Proposed change

We can disable this limitation once core and supervisor supports history backup without config.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
