### PR TITLE
Allow `multiple: true` for expandable sections

### DIFF
--- a/src/components/ha-form/ha-form-expandable.ts
+++ b/src/components/ha-form/ha-form-expandable.ts
@@ -144,15 +144,19 @@ export class HaFormExpendable extends LitElement implements HaFormElement {
               : nothing}
           ${this.schema.title || this.computeLabel?.(this.schema)}
         </div>
-        <ha-icon-button
-          slot="icons"
-          .disabled=${this.disabled}
-          .label=${this.hass.localize("ui.common.delete")}
-          .index=${index}
-          @click=${this._deleteItem}
-        >
-          <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
-        </ha-icon-button>
+        ${this.schema.multiple
+          ? html`
+              <ha-icon-button
+                slot="icons"
+                .disabled=${this.disabled}
+                .label=${this.hass.localize("ui.common.delete")}
+                .index=${index}
+                @click=${this._deleteItem}
+              >
+                <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
+              </ha-icon-button>
+            `
+          : nothing}
         <div class="content">
           ${this.schema.multiple ? nothing : this._renderDescription()}
           <ha-form

--- a/src/components/ha-form/types.ts
+++ b/src/components/ha-form/types.ts
@@ -43,6 +43,7 @@ export interface HaFormExpandableSchema extends HaFormBaseSchema {
   icon?: string;
   iconPath?: string;
   expanded?: boolean;
+  multiple?: boolean;
   headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
   schema: readonly HaFormSchema[];
 }
@@ -127,6 +128,6 @@ export type HaFormTimeData = HaDurationData;
 
 export interface HaFormElement extends LitElement {
   schema: HaFormSchema | readonly HaFormSchema[];
-  data?: HaFormDataContainer | HaFormData;
+  data?: HaFormDataContainer | HaFormDataContainer[] | HaFormData;
   label?: string;
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Allow setting `multiple: true` for an expandable section, which would mean that that section now behaves like a group of selectors, with user allowed to submit multiple copies of the data requested by the section. 

Backend PR: https://github.com/home-assistant/core/pull/131393

Based on a concept idea by Frenck: https://github.com/home-assistant/core/pull/121857#discussion_r1687060514

Example: entering datapoint pairs, where the user can submit a list, and each list item is two numbers:

![mutli-section](https://github.com/user-attachments/assets/7a97aaf0-8e0a-497d-b175-0c1e3581e47a)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
