### PR TITLE
Make key_c_hint strings consistent

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1197,7 +1197,7 @@
         },
         "filter_placeholder": "Search entities",
         "title": "Quick search",
-        "key_c_hint": "Press 'c' on any page to open the search bar",
+        "key_c_hint": "Press 'c' on any page to open the command dialog",
         "nothing_found": "Nothing found!"
       },
       "voice_command": {


### PR DESCRIPTION
At the bottom of setting the `ui::tips::key_c_hint` shows up in rotation with other hints:

![Screenshot 2024-11-23 15 08 27](https://github.com/user-attachments/assets/7ee69421-211f-4314-9c41-31529d23ad54)

When you do so the Quick search dialog opens and displays this hint at the bottom:

![Screenshot 2024-11-23 15 08 40](https://github.com/user-attachments/assets/f2bd7534-fa8d-46b7-b4a6-acdcdd82547f)

The latter should be made consistent with the first by using "command dialog" in both places as "c" maps to "command".

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Makes the 'key_c_hint' identical by using:
"Press 'c' on any page to open the command dialog"

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
