### PR TITLE
Fix back button tooltip in Entity history dialog

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1235,7 +1235,7 @@
         "settings": "Settings",
         "edit": "Edit entity",
         "details": "Details",
-        "back_to_info": "Back to info",
+        "back_to_info": "Back to More info",
         "info": "Information",
         "related": "Related",
         "history": "History",


### PR DESCRIPTION
The back button in an entity's History view brings the user back to the 'More info' dialog:

![Back to (More) info](https://github.com/user-attachments/assets/10b450ea-89a0-41a4-ac85-561bf7557196)

The tooltip needs to reflect that by using "Back to More info" for a consistent naming of that dialog.

Example for reference:

https://github.com/home-assistant/frontend/blob/999969b78d5d6d1d9450fb76ca59b1f70d30833c/src/translations/en.json#L6386

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Replace "Back to info" with "Back to More info".

As "More info" is the name of the dialog in HA the first letter is capitalized.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
