### PR TITLE
Add missing header strings for "automation" and "edit"

### DIFF
--- a/src/panels/config/tags/ha-config-tags.ts
+++ b/src/panels/config/tags/ha-config-tags.ts
@@ -115,6 +115,7 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
     }
     columns.automation = {
       title: "",
+      label: localize("ui.panel.config.tag.headers.automation"),
       type: "icon-button",
       showNarrow: true,
       template: (tag) =>
@@ -127,6 +128,7 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
     };
     columns.edit = {
       title: "",
+      label: localize("ui.panel.config.tag.headers.edit"),
       type: "icon-button",
       showNarrow: true,
       hideable: false,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2224,7 +2224,9 @@
             "icon": "Icon",
             "name": "Name",
             "last_scanned": "Last scanned",
-            "write": "Write"
+            "write": "Write",
+            "automation": "Create automation",
+            "edit": "Edit"
           },
           "detail": {
             "new_tag": "New tag",


### PR DESCRIPTION
In the Tags list the two column headers for the "Create automation" and the "Edit" buttons are missing the strings to translate:

![Screenshot 2024-10-23 15 59 22](https://github.com/user-attachments/assets/0e0fef38-0621-4d10-a939-87f01cc62e97)

Should be
- Create automation
- Edit

Note that both columns are buttons, their tooltips are:

- Create automation with tag
- Edit

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add the missing strings for translation.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22498 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
