### PR TITLE
Mark delete backup dialog as destructive

### DIFF
--- a/hassio/src/backups/hassio-backups.ts
+++ b/hassio/src/backups/hassio-backups.ts
@@ -323,6 +323,7 @@ export class HassioBackups extends LitElement {
         number: this._selectedBackups.length,
       }),
       confirmText: this.supervisor.localize("backup.delete_backup_confirm"),
+      destructive: true,
     });
 
     if (!confirm) {

--- a/hassio/src/dialogs/backup/dialog-hassio-backup.ts
+++ b/hassio/src/dialogs/backup/dialog-hassio-backup.ts
@@ -302,6 +302,7 @@ class HassioBackupDialog
         text: supervisor!.localize("backup.confirm_delete_text"),
         confirmText: supervisor!.localize("backup.delete"),
         dismissText: supervisor!.localize("backup.cancel"),
+        destructive: true,
       }))
     ) {
       return;


### PR DESCRIPTION
## Proposed change

Add `destructive` parameter to delete backup confirmation dialogs.

Old:

<img width="520" alt="image" src="https://github.com/user-attachments/assets/75f04055-57ed-4141-9d5a-ede2a56ce7c6">
<img width="384" alt="image" src="https://github.com/user-attachments/assets/5596d5ad-610a-4061-9293-ea4c157a9e2b">

New:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/52bd363c-dad7-4357-a9ec-579550d7ae5c">
<img width="417" alt="image" src="https://github.com/user-attachments/assets/e7a9a88b-c605-4a22-9556-7ea45511f6e1">



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21810
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
