### PR TITLE
Make missed strings translatable in `ha-script-trace` and `ha-automation-trace`

### DIFF
--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -424,7 +424,9 @@ export class HaAutomationTrace extends LitElement {
       }
 
       await showAlertDialog(this, {
-        text: "Chosen trace is no longer available",
+        text: this.hass!.localize(
+          "ui.panel.config.automation.trace.trace_no_longer_available"
+        ),
       });
     }
 
@@ -471,7 +473,11 @@ export class HaAutomationTrace extends LitElement {
   }
 
   private _importTrace() {
-    const traceText = prompt("Enter downloaded trace");
+    const traceText = prompt(
+      this.hass.localize(
+        "ui.panel.config.automation.trace.enter_downloaded_trace"
+      )
+    );
     if (!traceText) {
       return;
     }

--- a/src/panels/config/script/ha-script-trace.ts
+++ b/src/panels/config/script/ha-script-trace.ts
@@ -230,10 +230,30 @@ export class HaScriptTrace extends LitElement {
                     <div class="info">
                       <div class="tabs top">
                         ${[
-                          ["details", "Step Details"],
-                          ["timeline", "Trace Timeline"],
-                          ["logbook", "Related logbook entries"],
-                          ["config", "Script Config"],
+                          [
+                            "details",
+                            this.hass.localize(
+                              "ui.panel.config.automation.trace.tabs.details"
+                            ),
+                          ],
+                          [
+                            "timeline",
+                            this.hass.localize(
+                              "ui.panel.config.automation.trace.tabs.timeline"
+                            ),
+                          ],
+                          [
+                            "logbook",
+                            this.hass.localize(
+                              "ui.panel.config.automation.trace.tabs.logbook"
+                            ),
+                          ],
+                          [
+                            "config",
+                            this.hass.localize(
+                              "ui.panel.config.automation.trace.tabs.script_config"
+                            ),
+                          ],
                         ].map(
                           ([view, label]) => html`
                             <button
@@ -410,7 +430,9 @@ export class HaScriptTrace extends LitElement {
       }
 
       await showAlertDialog(this, {
-        text: "Chosen trace is no longer available",
+        text: this.hass!.localize(
+          "ui.panel.config.automation.trace.trace_no_longer_available"
+        ),
       });
     }
 
@@ -457,7 +479,11 @@ export class HaScriptTrace extends LitElement {
   }
 
   private _importTrace() {
-    const traceText = prompt("Enter downloaded trace");
+    const traceText = prompt(
+      this.hass.localize(
+        "ui.panel.config.automation.trace.enter_downloaded_trace"
+      )
+    );
     if (!traceText) {
       return;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3614,6 +3614,8 @@
             "older_trace": "Older trace",
             "newer_trace": "Newer trace",
             "no_traces_found": "No traces found",
+            "trace_no_longer_available": "Chosen trace is no longer available",
+            "enter_downloaded_trace": "Enter downloaded trace",
             "tabs": {
               "details": "Step Details",
               "timeline": "Trace Timeline",
@@ -3621,7 +3623,8 @@
               "automation_config": "Automation Config",
               "step_config": "Step Config",
               "changed_variables": "Changed Variables",
-              "blueprint_config": "Blueprint Config"
+              "blueprint_config": "Blueprint Config",
+              "script_config": "Script Config"
             },
             "path": {
               "choose": "Select a step on the left for more information.",


### PR DESCRIPTION
## Proposed change
Make some missed strings in `ha-script-trace` and `ha-automation-trace` translatable

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
