### PR TITLE
Dont floor duration for milliseconds

### DIFF
--- a/src/common/datetime/format_duration.ts
+++ b/src/common/datetime/format_duration.ts
@@ -165,7 +165,7 @@ export const formatDuration = (
       return formatDurationSecondMem(locale).format(input);
     }
     case "ms": {
-      const milliseconds = Math.floor(value);
+      const milliseconds = value;
       const input: DurationInput = {
         milliseconds,
       };

--- a/src/common/datetime/format_duration.ts
+++ b/src/common/datetime/format_duration.ts
@@ -72,7 +72,7 @@ export const formatDurationDigital = (
   duration: HaDurationData
 ) => formatDigitalDurationMem(locale).format(duration);
 
-export const DURATION_UNITS = ["ms", "s", "min", "h", "d"] as const;
+export const DURATION_UNITS = ["s", "min", "h", "d"] as const;
 
 type DurationUnit = (typeof DURATION_UNITS)[number];
 
@@ -105,14 +105,6 @@ const formatDurationSecondMem = memoizeOne(
     new DurationFormat(locale.language, {
       style: "narrow",
       secondsDisplay: "always",
-    })
-);
-
-const formatDurationMillisecondMem = memoizeOne(
-  (locale: FrontendLocaleData) =>
-    new DurationFormat(locale.language, {
-      style: "narrow",
-      millisecondsDisplay: "always",
     })
 );
 
@@ -163,13 +155,6 @@ export const formatDuration = (
         milliseconds,
       };
       return formatDurationSecondMem(locale).format(input);
-    }
-    case "ms": {
-      const milliseconds = value;
-      const input: DurationInput = {
-        milliseconds,
-      };
-      return formatDurationMillisecondMem(locale).format(input);
     }
     default:
       throw new Error("Invalid duration unit");

--- a/test/common/datetime/format_duration.test.ts
+++ b/test/common/datetime/format_duration.test.ts
@@ -21,14 +21,6 @@ const LOCALE: FrontendLocaleData = {
 
 describe("formatDuration", () => {
   it("works", () => {
-    assert.strictEqual(formatDuration(LOCALE, "0", "ms"), "0ms");
-    assert.strictEqual(formatDuration(LOCALE, "1", "ms"), "1ms");
-    assert.strictEqual(formatDuration(LOCALE, "10", "ms"), "10ms");
-    assert.strictEqual(formatDuration(LOCALE, "100", "ms"), "100ms");
-    assert.strictEqual(formatDuration(LOCALE, "1000", "ms"), "1,000ms");
-    assert.strictEqual(formatDuration(LOCALE, "1001", "ms"), "1,001ms");
-    assert.strictEqual(formatDuration(LOCALE, "65000", "ms"), "65,000ms");
-
     assert.strictEqual(formatDuration(LOCALE, "0.5", "s"), "0s 500ms");
     assert.strictEqual(formatDuration(LOCALE, "1", "s"), "1s");
     assert.strictEqual(formatDuration(LOCALE, "1.1", "s"), "1s 100ms");


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Really like the new duration changes! However I was thinking maybe when a duration is set to milliseconds, we don't need to force round it. 

If we don't floor, then the display is just controlled by display precision, so user can choose whole numbers or partial fraction. 

If we floor, then there is no choice, and anything sub-1ms is always forced to `0 ms`. 



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
