### PR TITLE
Fix iqs naming and docs link anchor

### DIFF
--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -354,25 +354,18 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                             : mdiMedal}
                         ></ha-svg-icon>
                         <span>
-                          ${this.hass.localize(
-                            `ui.panel.config.integrations.config_entry.${this._manifest.quality_scale as MedalColor}_quality`,
-                            {
-                              quality_scale: html`
-                                <a
-                                  href=${documentationUrl(
-                                    this.hass,
-                                    `/docs/quality_scale/#${this._manifest.quality_scale}-`
-                                  )}
-                                  rel="noopener noreferrer"
-                                  target="_blank"
-                                >
-                                  ${this.hass.localize(
-                                    "ui.panel.config.integrations.config_entry.quality_scale"
-                                  )}
-                                </a>
-                              `,
-                            }
-                          )}
+                          <a
+                            href=${documentationUrl(
+                              this.hass,
+                              `/docs/quality_scale/#-${this._manifest.quality_scale}`
+                            )}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            ${this.hass.localize(
+                              `ui.panel.config.integrations.config_entry.${this._manifest.quality_scale as MedalColor}_quality`
+                            )}
+                          </a>
                         </span>
                       </div>
                     `

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4521,11 +4521,10 @@
               "setup_in_progress": "Initializing"
             },
             "open_configuration_url": "Visit device",
-            "bronze_quality": "Bronze on our {quality_scale}",
-            "silver_quality": "Silver on our {quality_scale}",
-            "gold_quality": "Gold on our {quality_scale}",
-            "platinum_quality": "Platinum on our {quality_scale}",
-            "quality_scale": "quality scale"
+            "bronze_quality": "Bronze quality",
+            "silver_quality": "Silver quality",
+            "gold_quality": "Gold quality",
+            "platinum_quality": "Platinum quality"
           },
           "config_flow": {
             "success": "Success",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
- simplify IQS naming to just `<color> quality`
- fix IQS docs link anchor


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: home-assistant/home-assistant.io#36038

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
