### PR TITLE
Correctly match "Remove" to "Add" within Energy dashboard

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2244,19 +2244,19 @@
           "caption": "Energy",
           "description": "Monitor your energy production and consumption",
           "new_device_info": "After setting up a new device, it can take up to 2 hours for new data to arrive in your energy dashboard.",
-          "delete_source": "Are you sure you want to delete this source?",
-          "delete_integration": "Are you sure you want to delete this integration? It will remove the entities it provides",
+          "delete_source": "Are you sure you want to remove this source?",
+          "delete_integration": "Are you sure you want to remove this integration? It will remove the entities it provides",
           "grid": {
             "title": "Electricity grid",
             "sub": "Configure the amount of energy that you consume from the grid and, if you produce energy, give back to the grid. This allows Home Assistant to track your whole home energy usage.",
             "learn_more": "More information on how to get started.",
             "grid_consumption": "Grid consumption",
             "edit_consumption": "Edit consumption",
-            "delete_consumption": "Delete consumption",
+            "delete_consumption": "Remove consumption",
             "add_consumption": "Add consumption",
             "return_to_grid": "Return to grid",
             "edit_return": "Edit return",
-            "delete_return": "Delete return",
+            "delete_return": "Remove return",
             "add_return": "Add return",
             "grid_carbon_footprint": "Grid carbon footprint",
             "remove_co2_signal": "Remove Electricity Maps integration",
@@ -2298,7 +2298,7 @@
             "learn_more": "More information on how to get started.",
             "solar_production": "Solar production",
             "edit_solar_production": "Edit solar production",
-            "delete_solar_production": "Delete solar production",
+            "delete_solar_production": "Remove solar production",
             "add_solar_production": "Add solar production",
             "stat_production": "Your solar energy production",
             "stat_return_to_grid": "Solar energy returned to the grid",
@@ -2320,7 +2320,7 @@
             "learn_more": "More information on how to get started.",
             "battery_systems": "Battery systems",
             "edit_battery_system": "Edit battery system",
-            "delete_battery_system": "Delete battery system",
+            "delete_battery_system": "Remove battery system",
             "add_battery_system": "Add battery system",
             "dialog": {
               "header": "Configure battery system",
@@ -2335,7 +2335,7 @@
             "learn_more": "More information on how to get started.",
             "gas_consumption": "Gas consumption",
             "edit_gas_source": "Edit gas source",
-            "delete_gas_source": "Delete gas source",
+            "delete_gas_source": "Remove gas source",
             "add_gas_source": "Add gas source",
             "dialog": {
               "header": "Configure gas consumption",
@@ -2359,7 +2359,7 @@
             "learn_more": "More information on how to get started.",
             "water_consumption": "Water consumption",
             "edit_water_source": "Edit water source",
-            "delete_water_source": "Delete water source",
+            "delete_water_source": "Remove water source",
             "add_water_source": "Add water source",
             "dialog": {
               "header": "Configure water consumption",
@@ -2387,7 +2387,7 @@
             "dialog": {
               "header": "Add a device",
               "display_name": "Display name",
-              "device_consumption_energy": "Device consumption energy",
+              "device_consumption_energy": "Device energy consumption",
               "selected_stat_intro": "Select the energy sensor that measures the device's energy usage in either of {unit}."
             }
           }


### PR DESCRIPTION
In Home Assistant the action "Add" should always pair with "Remove", like "Create" does with "Delete". This commit addresses all mismatched pairs in the Energy dashboard. Most strings are the tooltips for the trash can icons.

Note that we already have a few correct "removes" in this context so this brings more consistency, too.

In addition the grammar of 'device_consumption_energy' that is shown when setting up individual devices is fixed by using the consistent "energy consumption" word pair:

![Screenshot 2024-11-30 13 48 31](https://github.com/user-attachments/assets/2af4dd38-628f-44f7-8172-2dd6f5858ab7)

This caused a bit of discussion for the German translation so having this correct and consistent might help other translators, too.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Replace "delete" with "remove" on all affected lines.
For most of these the matching "add" is found in the line just below.

Fix the confusing "Device consumption energy" by replacing it with "Device energy consumption".

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
