### PR TITLE
Remove the misleading word "updates" from system options

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1658,10 +1658,10 @@
       },
       "config_entry_system_options": {
         "title": "System options for {integration}",
-        "enable_new_entities_label": "Enable newly added entities.",
+        "enable_new_entities_label": "Enable newly added entities",
         "enable_new_entities_description": "If newly discovered devices for {integration} should be automatically added.",
-        "enable_polling_label": "Enable polling for updates.",
-        "enable_polling_description": "If Home Assistant should automatically poll {integration} entities for updates.",
+        "enable_polling_label": "Enable polling for changes",
+        "enable_polling_description": "If Home Assistant should automatically poll {integration} entities for state changes.",
         "restart_home_assistant": "You need to restart Home Assistant for your changes to take effect.",
         "update": "Update"
       },


### PR DESCRIPTION
The second option in the system options dialog for integrations uses the word "updates" in both the headline and the explanation.

![Screenshot 2024-11-26 09 33 19](https://github.com/user-attachments/assets/99c6b56c-3408-4136-8c3e-eecf7a688e75)

This is highly misleading as it sounds like polling for firmware updates for all device integrations.
Many users who are not aware of the internal poll or push update mechanisms will misread it as such.
As the German translators did (fixed in October).

Therefore the words "(state) changes" should be used instead.

Note that even the main button in the dialog is "Update" which adds to the possible confusion, too. 

In addition headlines should not end with a period so this PR removes them both as well.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Replace "updates" with "changes" in the headline.
Explain this as "state changes" in the description avoiding "updates" alltogether.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
