### PR TITLE
Add shortcut to open the voice assist dialog

### DIFF
--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -96,7 +96,12 @@ const randomTip = (hass: HomeAssistant, narrow: boolean) => {
         weight: 1,
         narrow: false,
       },
-      { content: hass.localize("ui.tips.key_m_hint"), weight: 1, narrow: false }
+      {
+        content: hass.localize("ui.tips.key_m_hint"),
+        weight: 1,
+        narrow: false,
+      },
+      { content: hass.localize("ui.tips.key_a_hint"), weight: 1, narrow: false }
     );
   }
 

--- a/src/state/quick-bar-mixin.ts
+++ b/src/state/quick-bar-mixin.ts
@@ -1,5 +1,6 @@
 import type { PropertyValues } from "lit";
 import { tinykeys } from "tinykeys";
+import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { mainWindow } from "../common/dom/get_main_window";
 import type { QuickBarParams } from "../dialogs/quick-bar/show-dialog-quick-bar";
@@ -64,10 +65,15 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
       });
     }
 
+    private _conversation = memoizeOne((_components) =>
+      isComponentLoaded(this.hass!, "conversation")
+    );
+
     private _showVoiceCommandDialog(e: KeyboardEvent) {
       if (
         !this.hass?.enableShortcuts ||
-        !this._canOverrideAlphanumericInput(e)
+        !this._canOverrideAlphanumericInput(e) ||
+        !this._conversation(this.hass.config.components)
       ) {
         return;
       }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7547,7 +7547,8 @@
     "tips": {
       "key_c_hint": "Press 'c' on any page to open the command dialog",
       "key_e_hint": "Press 'e' on any page to open the entity search dialog",
-      "key_m_hint": "Press 'm' on any page to get the My Home Assistant link"
+      "key_m_hint": "Press 'm' on any page to get the My Home Assistant link",
+      "key_a_hint": "Press 'a' on any page to open the voice assist dialog"
     }
   },
   "landing-page": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7548,7 +7548,7 @@
       "key_c_hint": "Press 'c' on any page to open the command dialog",
       "key_e_hint": "Press 'e' on any page to open the entity search dialog",
       "key_m_hint": "Press 'm' on any page to get the My Home Assistant link",
-      "key_a_hint": "Press 'a' on any page to open the voice assist dialog"
+      "key_a_hint": "Press 'a' on any page to open the Assist dialog"
     }
   },
   "landing-page": {


### PR DESCRIPTION
## Proposed change
Add a shortcut (key A) to open the voice assist dialog on every page.

WTH: https://community.home-assistant.io/t/wth-there-is-no-hotkey-for-assist/802403

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
