### PR TITLE
ZwaveJS: Handle S2 inclusion via Inclusion Controller

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -398,6 +398,11 @@ export interface ZWaveJSRemovedNode {
   label: string;
 }
 
+export interface ZWaveJSS2InclusionValidateDskAndEnterPinMessage {
+  event: "validate dsk and enter pin";
+  dsk: string;
+}
+
 export const enum NodeStatus {
   Unknown,
   Asleep,
@@ -805,6 +810,21 @@ export const subscribeZwaveNodeStatistics = (
     {
       type: "zwave_js/subscribe_node_statistics",
       device_id,
+    }
+  );
+
+export const subscribeS2Inclusion = (
+  hass: HomeAssistant,
+  entry_id: string,
+  callbackFunction: (
+    message: ZWaveJSS2InclusionValidateDskAndEnterPinMessage
+  ) => void
+): Promise<UnsubscribeFunc> =>
+  hass.connection.subscribeMessage(
+    (message: any) => callbackFunction(message),
+    {
+      type: "zwave_js/subscribe_s2_inclusion",
+      entry_id,
     }
   );
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -104,11 +104,21 @@ class DialogZWaveJSAddNode extends LitElement {
   }
 
   public async showDialog(params: ZWaveJSAddNodeDialogParams): Promise<void> {
+    if (this._status) {
+      // already started
+      return;
+    }
     this._params = params;
     this._entryId = params.entry_id;
     this._status = "loading";
     this._checkSmartStartSupport();
-    this._startInclusion();
+    if (params.dsk) {
+      this._status = "validate_dsk_enter_pin";
+      this._dsk = params.dsk;
+      this._startInclusion(undefined, params.dsk);
+    } else {
+      this._startInclusion();
+    }
   }
 
   @query("#pin-input") private _pinInput?: HaTextField;

--- a/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-add-node.ts
@@ -2,6 +2,7 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 
 export interface ZWaveJSAddNodeDialogParams {
   entry_id: string;
+  dsk?: string;
   onStop?: () => void;
 }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -36,6 +36,7 @@ import {
   fetchZwaveProvisioningEntries,
   InclusionState,
   setZwaveDataCollectionPreference,
+  subscribeS2Inclusion,
   subscribeZwaveControllerStatistics,
 } from "../../../../../data/zwave_js";
 import { showOptionsFlowDialog } from "../../../../../dialogs/config-flow/show-dialog-options-flow";
@@ -102,6 +103,13 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
           this._statistics = message;
         }
       ),
+      subscribeS2Inclusion(this.hass, this.configEntryId, (message) => {
+        showZWaveJSAddNodeDialog(this, {
+          entry_id: this.configEntryId,
+          dsk: message.dsk,
+          onStop: () => setTimeout(() => this._fetchData(), 100),
+        });
+      }),
     ];
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Listen for the event and show the inclusion dialog with the PIN input when S2 inclusion has been initiated by the controller. Only while on the ZwaveJS configuration page.

Core PR: https://github.com/home-assistant/core/pull/132073

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/certification-backlog/issues/45
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
