### PR TITLE
Show unit for number domains

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -171,12 +171,23 @@ export const computeStateDisplayFromEntityAttributes = (
     domain === "number" ||
     domain === "input_number"
   ) {
+    const unit =
+      (entity?.translation_key &&
+        localize(
+          `component.${entity.platform}.entity.${domain}.${entity.translation_key}.unit_of_measurement`
+        )) ||
+      attributes.unit_of_measurement;
+
     // Format as an integer if the value and step are integers
-    return formatNumber(
+    const value = formatNumber(
       state,
       locale,
       getNumberFormatOptions({ state, attributes } as HassEntity, entity)
     );
+    if (unit) {
+      return `${value}${blankBeforeUnit(unit, locale)}${unit}`;
+    }
+    return value;
   }
 
   // state is a timestamp

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -84,7 +84,7 @@ export const computeStateDisplayFromEntityAttributes = (
         // fallback to default
       }
     }
-    if (!is_number_domain && attributes.device_class === "monetary") {
+    if (attributes.device_class === "monetary") {
       try {
         return formatNumber(state, locale, {
           style: "currency",

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -68,7 +68,6 @@ export const computeStateDisplayFromEntityAttributes = (
   ) {
     // state is duration
     if (
-      !is_number_domain &&
       attributes.device_class === "duration" &&
       attributes.unit_of_measurement &&
       DURATION_UNITS.includes(attributes.unit_of_measurement)

--- a/test/common/entity/compute_state_display.test.ts
+++ b/test/common/entity/compute_state_display.test.ts
@@ -269,6 +269,43 @@ describe("computeStateDisplay", () => {
     );
   });
 
+  describe("Localizes a number entity value with translated unit_of_measurement", () => {
+    const testDomain = (domain: string) => {
+      const entity_id = `${domain}.test`;
+      const stateObj: any = {
+        entity_id: entity_id,
+        state: "1234",
+        attributes: {},
+      };
+      const entities: any = {
+        [entity_id]: {
+          translation_key: "custom_translation",
+          platform: "custom_integration",
+        },
+      };
+      assert.strictEqual(
+        computeStateDisplay(
+          localize,
+          stateObj,
+          localeData,
+          numericDeviceClasses,
+          demoConfig,
+          entities
+        ),
+        `1,234 component.custom_integration.entity.${domain}.custom_translation.unit_of_measurement`
+      );
+    };
+    it("Localizes counter domain", () => {
+      testDomain("counter");
+    });
+    it("Localizes number domain", () => {
+      testDomain("number");
+    });
+    it("Localizes input_number domain", () => {
+      testDomain("input_number");
+    });
+  });
+
   describe("Localizes input_datetime with full date time", () => {
     const stateObj: any = {
       entity_id: "input_datetime.test",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This adds the unit of measurement (both static and localized) for number domains that are displayed as a slider. 
Numbers that are not displayed as slider do not use the formatEntityState() and already show the static unit of measurement (but not the localized ones).

![image](https://github.com/user-attachments/assets/496d2b62-4d8f-4bac-ae96-e2535caf4efe)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
