### PR TITLE
Show in assist pipeline debug when intent is preferred and processed locally

### DIFF
--- a/src/data/assist_pipeline.ts
+++ b/src/data/assist_pipeline.ts
@@ -104,12 +104,14 @@ interface PipelineIntentStartEvent extends PipelineEventBase {
   data: {
     engine: string;
     language: string;
+    prefer_local_intents: boolean;
     intent_input: string;
   };
 }
 interface PipelineIntentEndEvent extends PipelineEventBase {
   type: "intent-end";
   data: {
+    processed_locally: boolean;
     intent_output: ConversationResult;
   };
 }

--- a/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts
+++ b/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts
@@ -1,4 +1,5 @@
-import { css, html, LitElement, nothing, type TemplateResult } from "lit";
+import type { TemplateResult } from "lit";
+import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../../components/ha-card";
 import "../../../../components/ha-alert";
@@ -306,27 +307,18 @@ export class AssistPipelineDebug extends LitElement {
                                   </div>`
                                 : ""}`
                           : ""}
-                        ${"prefer_local_intents" in this.pipelineRun.intent
-                          ? html`
-                              <div class="row">
-                                <div>Prefer handling locally</div>
-                                <div>
-                                  ${this.pipelineRun.intent
-                                    .prefer_local_intents}
-                                </div>
-                              </div>
-                            `
-                          : nothing}
-                        ${"processed_locally" in this.pipelineRun.intent
-                          ? html`
-                              <div class="row">
-                                <div>Processed locally</div>
-                                <div>
-                                  ${this.pipelineRun.intent.processed_locally}
-                                </div>
-                              </div>
-                            `
-                          : nothing}
+                        <div class="row">
+                          <div>Prefer handling locally</div>
+                          <div>
+                            ${this.pipelineRun.intent.prefer_local_intents}
+                          </div>
+                        </div>
+                        <div class="row">
+                          <div>Processed locally</div>
+                          <div>
+                            ${this.pipelineRun.intent.processed_locally}
+                          </div>
+                        </div>
                         ${dataMinusKeysRender(
                           this.pipelineRun.intent,
                           INTENT_DATA

--- a/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts
+++ b/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts
@@ -1,5 +1,4 @@
-import type { TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../../components/ha-card";
 import "../../../../components/ha-alert";
@@ -307,6 +306,27 @@ export class AssistPipelineDebug extends LitElement {
                                   </div>`
                                 : ""}`
                           : ""}
+                        ${"prefer_local_intents" in this.pipelineRun.intent
+                          ? html`
+                              <div class="row">
+                                <div>Prefer handling locally</div>
+                                <div>
+                                  ${this.pipelineRun.intent
+                                    .prefer_local_intents}
+                                </div>
+                              </div>
+                            `
+                          : nothing}
+                        ${"processed_locally" in this.pipelineRun.intent
+                          ? html`
+                              <div class="row">
+                                <div>Processed locally</div>
+                                <div>
+                                  ${this.pipelineRun.intent.processed_locally}
+                                </div>
+                              </div>
+                            `
+                          : nothing}
                         ${dataMinusKeysRender(
                           this.pipelineRun.intent,
                           INTENT_DATA


### PR DESCRIPTION
## Proposed change
Show on the assist pipeline debug page if a run was processed locally and if the pipeline prefers local processing. 

![image](https://github.com/user-attachments/assets/5c9a940a-1a54-42ed-b04e-81a0e88f2ab6)

Core PR: home-assistant/core#132166

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- link to core PR: home-assistant/core#132166

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
