### PR TITLE
Fix Markdown cards in Grid not taking full height

### DIFF
--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -111,7 +111,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
       this._config.show_empty === false &&
       this._templateResult.result.length === 0;
     if (shouldBeHidden !== this.hidden) {
-      this.style.display = shouldBeHidden ? "none" : "block";
+      this.style.display = shouldBeHidden ? "none" : "";
       this.toggleAttribute("hidden", shouldBeHidden);
       fireEvent(this, "card-visibility-changed", { value: !shouldBeHidden });
     }


### PR DESCRIPTION
## Proposed change

The implementation of show_empty property in #21379 introduced regression which causes Markdown cards rendered within a Grid card to not take full height of its space. This is because a visible card is now forced to have "display: block", while without that it's rendered as "display: inline".

As the CSSStyleDeclaration.style mandates string type, it's not possible to delete or null the value. Setting it to an empty string seems to do the trick as well and the linter is happy too.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: grid
cards:
  - type: markdown
    content: ' '
  - show_name: true
    show_icon: true
    type: button
    tap_action:
      action: toggle
    entity: zone.home
  - type: markdown
    content: ' '

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23119
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
