### PR TITLE
Add toggle switch for exposing of new entities to Assist

### DIFF
--- a/src/panels/config/voice-assistants/assist-pref.ts
+++ b/src/panels/config/voice-assistants/assist-pref.ts
@@ -124,23 +124,6 @@ export class AssistPref extends LitElement {
             ></ha-icon-button>
           </a>
         </div>
-        <ha-settings-row>
-          <span slot="heading">
-            ${this.hass!.localize(
-              "ui.panel.config.voice_assistants.expose.expose_new_entities"
-            )}
-          </span>
-          <span slot="description">
-            ${this.hass!.localize(
-              "ui.panel.config.voice_assistants.expose.expose_new_entities_info"
-            )}
-          </span>
-          <ha-switch
-            .checked=${this._exposeNew}
-            .disabled=${this._exposeNew === undefined}
-            @change=${this._exposeNewToggleChanged}
-          ></ha-switch>
-        </ha-settings-row>
         <mwc-list>
           ${this._pipelines.map(
             (pipeline) => html`
@@ -225,6 +208,23 @@ export class AssistPref extends LitElement {
           )}
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
         </ha-button>
+        <ha-settings-row>
+          <span slot="heading">
+            ${this.hass!.localize(
+              "ui.panel.config.voice_assistants.expose.expose_new_entities"
+            )}
+          </span>
+          <span slot="description">
+            ${this.hass!.localize(
+              "ui.panel.config.voice_assistants.expose.expose_new_entities_info"
+            )}
+          </span>
+          <ha-switch
+            .checked=${this._exposeNew}
+            .disabled=${this._exposeNew === undefined}
+            @change=${this._exposeNewToggleChanged}
+          ></ha-switch>
+        </ha-settings-row>
         <div class="card-actions">
           <a
             href="/config/voice-assistants/expose?assistants=conversation&historyBack"
@@ -376,6 +376,7 @@ export class AssistPref extends LitElement {
         --mdc-list-item-meta-size: auto;
         --mdc-list-item-meta-display: flex;
         --mdc-list-side-padding-right: 8px;
+        --mdc-list-side-padding-left: 16px;
       }
 
       ha-list-item.danger {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2828,6 +2828,9 @@
               "header": "Expose entities",
               "expose_to": "to {assistants}",
               "expose_entities": "Expose {count} {count, plural,\n  one {entity}\n  other {entities}\n}"
+            },
+            "expose_new_entities": "Expose new entities",
+            "expose_new_entities_info": "Should new entities be exposed? Exposes supported devices that are not classified as security devices."
             }
           },
           "satellite_wizard": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2831,7 +2831,6 @@
             },
             "expose_new_entities": "Expose new entities",
             "expose_new_entities_info": "Should new entities be exposed? Exposes supported devices that are not classified as security devices."
-            }
           },
           "satellite_wizard": {
             "skip": "Skip",


### PR DESCRIPTION
## Proposed change
Added a toggle switch to disable the exposure of new entities for Assist. As far as I saw core already supports this, but there was no possibility in the frontend so far.

WTH: https://community.home-assistant.io/t/wth-are-all-new-entities-exposed-to-assist-by-default/803889
This seems to be a feature request as well: https://community.home-assistant.io/t/assist-dont-expose-newly-added-entities-automatically-to-it/598434

<img width="817" alt="image" src="https://github.com/user-attachments/assets/ffb2c019-4728-4e64-9df8-817b0b3c25dc">

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
