### PR TITLE
Revert translation change for device quick bar

### DIFF
--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -172,9 +172,11 @@ export class QuickBar extends LitElement {
     );
 
     const translationKey =
-      this._mode === QuickBarMode.Device ? "devices" : "entities";
+      this._mode === QuickBarMode.Device
+        ? "filter_placeholder_devices"
+        : "filter_placeholder";
     const placeholder = this.hass.localize(
-      `ui.dialogs.quick-bar.filter_placeholder.${translationKey}`
+      `ui.dialogs.quick-bar.${translationKey}`
     );
 
     const commandMode = this._mode === QuickBarMode.Command;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1195,10 +1195,8 @@
             "addon_info": "{addon} Info"
           }
         },
-        "filter_placeholder": {
-          "entities": "Search entities",
-          "devices": "Search devices"
-        },
+        "filter_placeholder": "Search entities",
+        "filter_placeholder_devices": "Search devices",
         "title": "Quick search",
         "key_c_hint": "Press 'c' on any page to open the command dialog",
         "nothing_found": "Nothing found!"


### PR DESCRIPTION
## Proposed change
Revert the translation change for the device quick bar as it breaks the current translations for the release.

/cc @bramkragten 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
