### PR TITLE
Don't use duration formatting for second unit

### DIFF
--- a/src/common/datetime/format_duration.ts
+++ b/src/common/datetime/format_duration.ts
@@ -71,7 +71,7 @@ export const formatDurationDigital = (
   duration: HaDurationData
 ) => formatDigitalDurationMem(locale).format(duration);
 
-export const DURATION_UNITS = ["s", "min", "h", "d"] as const;
+export const DURATION_UNITS = ["min", "h", "d"] as const;
 
 type DurationUnit = (typeof DURATION_UNITS)[number];
 
@@ -96,14 +96,6 @@ const formatDurationMinuteMem = memoizeOne(
     new Intl.DurationFormat(locale.language, {
       style: "narrow",
       minutesDisplay: "always",
-    })
-);
-
-const formatDurationSecondMem = memoizeOne(
-  (locale: FrontendLocaleData) =>
-    new Intl.DurationFormat(locale.language, {
-      style: "narrow",
-      secondsDisplay: "always",
     })
 );
 
@@ -145,15 +137,6 @@ export const formatDuration = (
         seconds,
       };
       return formatDurationMinuteMem(locale).format(input);
-    }
-    case "s": {
-      const seconds = Math.floor(value);
-      const milliseconds = Math.floor((value - seconds) * 1000);
-      const input: DurationInput = {
-        seconds,
-        milliseconds,
-      };
-      return formatDurationSecondMem(locale).format(input);
     }
     default:
       throw new Error("Invalid duration unit");

--- a/test/common/datetime/format_duration.test.ts
+++ b/test/common/datetime/format_duration.test.ts
@@ -21,11 +21,6 @@ const LOCALE: FrontendLocaleData = {
 
 describe("formatDuration", () => {
   it("works", () => {
-    assert.strictEqual(formatDuration(LOCALE, "0.5", "s"), "0s 500ms");
-    assert.strictEqual(formatDuration(LOCALE, "1", "s"), "1s");
-    assert.strictEqual(formatDuration(LOCALE, "1.1", "s"), "1s 100ms");
-    assert.strictEqual(formatDuration(LOCALE, "65", "s"), "65s");
-
     assert.strictEqual(formatDuration(LOCALE, "0.25", "min"), "0m 15s");
     assert.strictEqual(formatDuration(LOCALE, "0.5", "min"), "0m 30s");
     assert.strictEqual(formatDuration(LOCALE, "1", "min"), "1m");


### PR DESCRIPTION
## Proposed change

Don't use duration formatting for second unit

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
