### PR TITLE
Use action instead of selected for select entity row

### DIFF
--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-local.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-local.ts
@@ -24,7 +24,6 @@ import type { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
 import { AssistantSetupStyles } from "./styles";
 import { STEP } from "./voice-assistant-setup-dialog";
-import { nextRender } from "../../common/util/render-status";
 
 @customElement("ha-voice-assistant-setup-step-local")
 export class HaVoiceAssistantSetupStepLocal extends LitElement {
@@ -333,9 +332,6 @@ export class HaVoiceAssistantSetupStepLocal extends LitElement {
       this._localTts[0].entity_id,
       this._localStt[0].entity_id
     );
-
-    // wait a render so the `hui-select-entity-row` is also updated and doesn't undo the select action
-    await nextRender();
 
     await this.hass.callService(
       "select",

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-local.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-local.ts
@@ -253,9 +253,6 @@ export class HaVoiceAssistantSetupStepLocal extends LitElement {
         this._localTts[0].entity_id,
         this._localStt[0].entity_id
       );
-
-      // wait a render so the `hui-select-entity-row` is also updated and doesn't undo the select action
-      await nextRender();
     }
 
     await this.hass.callService(

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-pipeline.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-pipeline.ts
@@ -17,7 +17,6 @@ import type { HomeAssistant } from "../../types";
 import { AssistantSetupStyles } from "./styles";
 import { STEP } from "./voice-assistant-setup-dialog";
 import { documentationUrl } from "../../util/documentation-url";
-import { nextRender } from "../../common/util/render-status";
 
 @customElement("ha-voice-assistant-setup-step-pipeline")
 export class HaVoiceAssistantSetupStepPipeline extends LitElement {
@@ -241,9 +240,6 @@ export class HaVoiceAssistantSetupStepPipeline extends LitElement {
         wake_word_entity: null,
         wake_word_id: null,
       });
-
-      // wait a render so the `hui-select-entity-row` is also updated and doesn't undo the select action
-      await nextRender();
     }
 
     await this.hass.callService(

--- a/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
@@ -63,7 +63,7 @@ class HuiSelectEntityRow extends LitElement implements LovelaceRow {
           .value=${stateObj.state}
           .disabled=${stateObj.state === UNAVAILABLE}
           naturalMenuWidth
-          @selected=${this._selectedChanged}
+          @action=${this._handleAction}
           @click=${stopPropagation}
           @closed=${stopPropagation}
         >
@@ -94,11 +94,13 @@ class HuiSelectEntityRow extends LitElement implements LovelaceRow {
     `;
   }
 
-  private _selectedChanged(ev): void {
+  private _handleAction(ev): void {
     const stateObj = this.hass!.states[
       this._config!.entity
     ] as InputSelectEntity;
+
     const option = ev.target.value;
+
     if (
       option === stateObj.state ||
       !stateObj.attributes.options.includes(option)


### PR DESCRIPTION


## Proposed change

To prevent something happening when the options change, use the `action` event instead of the `selected` event of `ha-select` in select entity row.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
