### PR TITLE
Improve generate backup dialog

### DIFF
--- a/src/data/backup.ts
+++ b/src/data/backup.ts
@@ -1,4 +1,6 @@
+import type { LocalizeFunc } from "../common/translations/localize";
 import type { HomeAssistant } from "../types";
+import { domainToName } from "./integration";
 
 export const enum BackupScheduleState {
   NEVER = "never",
@@ -216,4 +218,20 @@ export const getPreferredAgentForDownload = (agents: string[]) => {
     (agent) => agent.split(".")[0] === "backup"
   );
   return localAgents[0] || agents[0];
+};
+
+export const computeBackupAgentName = (
+  localize: LocalizeFunc,
+  agentId: string,
+  agentIds?: string[]
+) => {
+  const [domain, name] = agentId.split(".");
+  const domainName = domainToName(localize, domain);
+
+  // If there are multiple agents for a domain, show the name
+  const showName = agentIds
+    ? agentIds.filter((a) => a.split(".")[0] === domain).length > 1
+    : true;
+
+  return showName ? `${domainName}: ${name}` : domainName;
 };

--- a/src/panels/config/backup/components/ha-backup-config-agents.ts
+++ b/src/panels/config/backup/components/ha-backup-config-agents.ts
@@ -2,12 +2,15 @@ import type { PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeDomain } from "../../../../common/entity/compute_domain";
 import "../../../../components/ha-md-list";
 import "../../../../components/ha-md-list-item";
 import "../../../../components/ha-switch";
 import type { BackupAgent } from "../../../../data/backup";
-import { fetchBackupAgentsInfo } from "../../../../data/backup";
-import { domainToName } from "../../../../data/integration";
+import {
+  computeBackupAgentName,
+  fetchBackupAgentsInfo,
+} from "../../../../data/backup";
 import type { HomeAssistant } from "../../../../types";
 import { brandsUrl } from "../../../../util/brands-url";
 
@@ -36,13 +39,19 @@ class HaBackupConfigAgents extends LitElement {
   }
 
   protected render() {
+    const allAgentIds = this._agents.map((agent) => agent.agent_id);
+
     return html`
       ${this._agents.length > 0
         ? html`
             <ha-md-list>
               ${this._agents.map((agent) => {
-                const [domain, name] = agent.agent_id.split(".");
-                const domainName = domainToName(this.hass.localize, domain);
+                const domain = computeDomain(agent.agent_id);
+                const name = computeBackupAgentName(
+                  this.hass.localize,
+                  agent.agent_id,
+                  allAgentIds
+                );
                 return html`
                   <ha-md-list-item>
                     <img
@@ -57,7 +66,7 @@ class HaBackupConfigAgents extends LitElement {
                       alt=""
                       slot="start"
                     />
-                    <div slot="headline">${domainName}: ${name}</div>
+                    <div slot="headline">${name}</div>
                     <ha-switch
                       slot="end"
                       id=${agent.agent_id}

--- a/src/panels/config/backup/ha-config-backup-details.ts
+++ b/src/panels/config/backup/ha-config-backup-details.ts
@@ -3,6 +3,7 @@ import { mdiDelete, mdiDotsVertical, mdiDownload } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { formatDateTime } from "../../../common/datetime/format_date_time";
+import { computeDomain } from "../../../common/entity/compute_domain";
 import { navigate } from "../../../common/navigate";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
@@ -16,6 +17,7 @@ import "../../../components/ha-md-list-item";
 import { getSignedPath } from "../../../data/auth";
 import type { BackupContentExtended } from "../../../data/backup";
 import {
+  computeBackupAgentName,
   deleteBackup,
   fetchBackupDetails,
   getBackupDownloadUrl,
@@ -23,7 +25,6 @@ import {
   restoreBackup,
 } from "../../../data/backup";
 import type { HassioAddonInfo } from "../../../data/hassio/addon";
-import { domainToName } from "../../../data/integration";
 import "../../../layouts/hass-subpage";
 import type { HomeAssistant } from "../../../types";
 import { brandsUrl } from "../../../util/brands-url";
@@ -142,10 +143,11 @@ class HaConfigBackupDetails extends LitElement {
                     <div class="card-content">
                       <ha-md-list>
                         ${this._backup.agent_ids?.map((agent) => {
-                          const [domain, name] = agent.split(".");
-                          const domainName = domainToName(
+                          const domain = computeDomain(agent);
+                          const name = computeBackupAgentName(
                             this.hass.localize,
-                            domain
+                            agent,
+                            this._backup!.agent_ids!
                           );
 
                           return html`
@@ -162,7 +164,7 @@ class HaConfigBackupDetails extends LitElement {
                                 alt=""
                                 slot="start"
                               />
-                              <div slot="headline">${domainName}: ${name}</div>
+                              <div slot="headline">${name}</div>
                               <ha-button-menu
                                 slot="end"
                                 @action=${this._handleAgentAction}


### PR DESCRIPTION
## Proposed change

Only display the domain for agents (the name is only show if there is more than 2 agents with the same domain)
Remove password is generate backup dialog
Use `ha-md-list-item` instead of `ha-settings-row`

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
