### PR TITLE
Update calendar card to allow variable height, better multi-day event support

### DIFF
--- a/src/panels/lovelace/cards/hui-calendar-card.ts
+++ b/src/panels/lovelace/cards/hui-calendar-card.ts
@@ -1,6 +1,7 @@
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
 import { getColorByIndex } from "../../../common/color/colors";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import type { HASSDomEvent } from "../../../common/dom/fire_event";
@@ -115,6 +116,11 @@ export class HuiCalendarCard extends LitElement implements LovelaceCard {
       "listWeek",
     ];
 
+    const style = {
+      "--calendar-height":
+        (this._config.height ? this._config.height : 400) + "px",
+    };
+
     return html`
       <ha-card>
         <div class="header">${this._config.title}</div>
@@ -127,6 +133,7 @@ export class HuiCalendarCard extends LitElement implements LovelaceCard {
           .eventDisplay=${this._eventDisplay}
           .error=${this._error}
           @view-changed=${this._handleViewChanged}
+          style=${styleMap(style)}
         ></ha-full-calendar>
       </ha-card>
     `;
@@ -154,8 +161,12 @@ export class HuiCalendarCard extends LitElement implements LovelaceCard {
   }
 
   private _handleViewChanged(ev: HASSDomEvent<CalendarViewChanged>): void {
-    this._eventDisplay =
-      ev.detail.view === "dayGridMonth" ? "list-item" : "auto";
+    if (this._config.multi_day) {
+      this._eventDisplay = "auto";
+    } else {
+      this._eventDisplay =
+        ev.detail.view === "dayGridMonth" ? "list-item" : "auto";
+    }
     this._startDate = ev.detail.start;
     this._endDate = ev.detail.end;
     this._fetchCalendarEvents();
@@ -229,10 +240,6 @@ export class HuiCalendarCard extends LitElement implements LovelaceCard {
         padding-left: 8px;
         padding-inline-start: 8px;
         direction: var(--direction);
-      }
-
-      ha-full-calendar {
-        --calendar-height: 400px;
       }
     `;
   }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -41,6 +41,8 @@ export interface CalendarCardConfig extends LovelaceCardConfig {
   initial_view?: FullCalendarView;
   title?: string;
   theme?: string;
+  height?: number;
+  multi_day?: boolean;
 }
 
 export interface ConditionalCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-calendar-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-calendar-card-editor.ts
@@ -10,6 +10,7 @@ import {
   optional,
   string,
   union,
+  number,
 } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
@@ -28,6 +29,8 @@ const cardConfigStruct = assign(
     initial_view: optional(string()),
     theme: optional(string()),
     entities: array(string()),
+    height: optional(number()),
+    multi_day: optional(boolean()),
   })
 );
 
@@ -69,6 +72,12 @@ export class HuiCalendarCardEditor
                 },
               },
             },
+            {
+              name: "height",
+              required: false,
+              selector: { number: { mode: "box", step: "any" } },
+            },
+            { name: "multi_day", required: false, selector: { boolean: {} } },
           ],
         },
         { name: "theme", required: false, selector: { theme: {} } },
@@ -124,6 +133,14 @@ export class HuiCalendarCardEditor
   ) => {
     if (schema.name === "title") {
       return this.hass!.localize("ui.panel.lovelace.editor.card.generic.title");
+    }
+
+    if (schema.name === "height") {
+      return "Height in pixels (default 400)";
+    }
+
+    if (schema.name === "multi_day") {
+      return "Display Multi-Day Blocks";
     }
 
     if (schema.name === "theme") {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This allows the Calendar card to behave the same way as the Calendar panel from the sidebar, where multi-day events are displayed in blocks spanning the calendar rather than on the start date only.

This revisits a design decision made in #14660, where the behavior was allowed to differentiate.  The argument in that PR was that the Calendar Card was too cramped to effectively display the multi-day events, so I've also added an option to choose the card's height.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: calendar
entities:
  - calendar.local_test
multi_day: true
height: 900
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36201

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
