### PR TITLE
Fix visibility for shown entities on device card (2)

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -266,10 +266,20 @@ export class HaDeviceEntitiesCard extends LitElement {
         color: var(--secondary-text-color);
       }
       .move-up {
+        margin-top: -13px;
+      }
+      .move-up:has(> mwc-list) {
         margin-top: -24px;
       }
-      #entities > * {
-        margin: 8px 16px 8px 8px;
+      :not(.move-up) > mwc-list {
+        margin-top: -24px;
+      }
+      mwc-list + button.show-more,
+      .move-up + :not(:has(mwc-list)) > button.show-more {
+        margin-top: -12px;
+      }
+      #entities > mwc-list {
+        margin: 0 16px 0 8px;
       }
       #entities > paper-icon-item {
         margin: 0;
@@ -304,6 +314,9 @@ export class HaDeviceEntitiesCard extends LitElement {
       button.show-more:focus {
         outline: none;
         text-decoration: underline;
+      }
+      mwc-list > * {
+        margin: 8px 0px;
       }
       ha-list-item {
         height: 40px;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Further improvements after https://github.com/home-assistant/frontend/pull/22579:

1. Currently entity rows do not look like Entities card - rows are vertically "squeezed":
![image](https://github.com/user-attachments/assets/d89634cc-67ab-4474-adb4-3383cb588031)

2. Vertical spacing between the last row & "Show more/less button" is too much:
![image](https://github.com/user-attachments/assets/68d6c4c2-6b03-4473-9abc-dc8d44ff20e5)
The difference clearly visible here:
![image](https://github.com/user-attachments/assets/f77c8493-3063-40de-b4c4-c785431fe70b)

3. Vertical spacing between enabled & disabled entities:
![image](https://github.com/user-attachments/assets/741f5229-e638-478d-bd4b-46603f0ff569)

After the fix:
![image](https://github.com/user-attachments/assets/cdada513-46cd-4572-8041-39f8c73ebdaf)

![image](https://github.com/user-attachments/assets/126d2168-3e20-4a2f-aa15-7b928d23d9ee)

![image](https://github.com/user-attachments/assets/89ac2ebc-49f1-40a5-aaea-121e6e617904)

![image](https://github.com/user-attachments/assets/bdce76e5-78ab-4106-9043-e95f050aed4a)

------------------

**Unrelated:**
Imho these lines may be removed:
```
      .entity-id {
        color: var(--secondary-text-color);
      }
      .buttons {
        text-align: right;
        margin: 0 0 0 8px;
      }
      ...
      #entities > paper-icon-item {
        margin: 0;
      }
      paper-icon-item {
        min-height: 40px;
        padding: 0 16px;
        cursor: pointer;
        --paper-item-icon-width: 48px;
      }
```
Do not see how they can affect a code...




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
