### PR TITLE
Ability to show map icons for geolocation sources

### DIFF
--- a/src/components/map/ha-entity-marker.ts
+++ b/src/components/map/ha-entity-marker.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css } from "lit";
 import { property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { fireEvent } from "../../common/dom/fire_event";
+import "../ha-icon";
 
 class HaEntityMarker extends LitElement {
   @property({ attribute: "entity-id" }) public entityId?: string;

--- a/src/components/map/ha-entity-marker.ts
+++ b/src/components/map/ha-entity-marker.ts
@@ -3,7 +3,7 @@ import { property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import type { HomeAssistant } from "../../types";
 import { fireEvent } from "../../common/dom/fire_event";
-import "../ha-icon";
+import "../ha-state-icon";
 
 class HaEntityMarker extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -16,7 +16,7 @@ class HaEntityMarker extends LitElement {
 
   @property({ attribute: "entity-color" }) public entityColor?: string;
 
-  @property({ attribute: "show-icon" }) public showIcon = false;
+  @property({ attribute: "show-icon", type: Boolean }) public showIcon = false;
 
   protected render() {
     return html`

--- a/src/components/map/ha-entity-marker.ts
+++ b/src/components/map/ha-entity-marker.ts
@@ -12,6 +12,8 @@ class HaEntityMarker extends LitElement {
 
   @property({ attribute: "entity-color" }) public entityColor?: string;
 
+  @property({ attribute: "entity-icon" }) public entityIcon?: string;
+
   protected render() {
     return html`
       <div
@@ -26,7 +28,9 @@ class HaEntityMarker extends LitElement {
                 "background-image": `url(${this.entityPicture})`,
               })}
             ></div>`
-          : this.entityName}
+          : this.entityIcon
+            ? html`<ha-icon .icon=${this.entityIcon}></ha-icon>`
+            : this.entityName}
       </div>
     `;
   }

--- a/src/components/map/ha-entity-marker.ts
+++ b/src/components/map/ha-entity-marker.ts
@@ -1,10 +1,13 @@
 import { LitElement, html, css } from "lit";
 import { property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
+import type { HomeAssistant } from "../../types";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../ha-icon";
 
 class HaEntityMarker extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
   @property({ attribute: "entity-id" }) public entityId?: string;
 
   @property({ attribute: "entity-name" }) public entityName?: string;
@@ -13,7 +16,7 @@ class HaEntityMarker extends LitElement {
 
   @property({ attribute: "entity-color" }) public entityColor?: string;
 
-  @property({ attribute: "entity-icon" }) public entityIcon?: string;
+  @property({ attribute: "show-icon" }) public showIcon = false;
 
   protected render() {
     return html`
@@ -29,8 +32,11 @@ class HaEntityMarker extends LitElement {
                 "background-image": `url(${this.entityPicture})`,
               })}
             ></div>`
-          : this.entityIcon
-            ? html`<ha-icon .icon=${this.entityIcon}></ha-icon>`
+          : this.showIcon && this.entityId
+            ? html`<ha-state-icon
+                .hass=${this.hass}
+                .stateObj=${this.hass?.states[this.entityId]}
+              ></ha-state-icon>`
             : this.entityName}
       </div>
     `;

--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -52,8 +52,7 @@ export interface HaMapPaths {
 export interface HaMapEntity {
   entity_id: string;
   color: string;
-  label_mode?: "name" | "state";
-  display_mode?: "icon";
+  label_mode?: "name" | "state" | "icon";
   name?: string;
   focus?: boolean;
 }
@@ -526,7 +525,7 @@ export class HaMap extends ReactiveElement {
 
       const entityIcon =
         (typeof entity !== "string" &&
-          entity.display_mode === "icon" &&
+          entity.label_mode === "icon" &&
           stateObj.attributes.icon) ||
         "";
       // create marker with the icon
@@ -538,7 +537,10 @@ export class HaMap extends ReactiveElement {
                 entity-name="${entityName}"
                 entity-icon="${entityIcon}"
                 entity-picture="${
-                  entityPicture ? this.hass.hassUrl(entityPicture) : ""
+                  !(typeof entity !== "string" && entity.label_mode) &&
+                  entityPicture
+                    ? this.hass.hassUrl(entityPicture)
+                    : ""
                 }"
                 ${
                   typeof entity !== "string"

--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -53,6 +53,7 @@ export interface HaMapEntity {
   entity_id: string;
   color: string;
   label_mode?: "name" | "state";
+  display_mode?: "icon";
   name?: string;
   focus?: boolean;
 }
@@ -523,6 +524,11 @@ export class HaMap extends ReactiveElement {
               .join("")
               .substr(0, 3));
 
+      const entityIcon =
+        (typeof entity !== "string" &&
+          entity.display_mode === "icon" &&
+          stateObj.attributes.icon) ||
+        "";
       // create marker with the icon
       const marker = Leaflet.marker([latitude, longitude], {
         icon: Leaflet.divIcon({
@@ -530,6 +536,7 @@ export class HaMap extends ReactiveElement {
               <ha-entity-marker
                 entity-id="${getEntityId(entity)}"
                 entity-name="${entityName}"
+                entity-icon="${entityIcon}"
                 entity-picture="${
                   entityPicture ? this.hass.hassUrl(entityPicture) : ""
                 }"

--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -523,32 +523,24 @@ export class HaMap extends ReactiveElement {
               .join("")
               .substr(0, 3));
 
-      const entityIcon =
-        (typeof entity !== "string" &&
-          entity.label_mode === "icon" &&
-          stateObj.attributes.icon) ||
-        "";
+      const entityMarker = document.createElement("ha-entity-marker");
+      entityMarker.hass = this.hass;
+      entityMarker.showIcon =
+        typeof entity !== "string" && entity.label_mode === "icon";
+      entityMarker.entityId = getEntityId(entity);
+      entityMarker.entityName = entityName;
+      entityMarker.entityPicture =
+        entityPicture && (typeof entity === "string" || !entity.label_mode)
+          ? this.hass.hassUrl(entityPicture)
+          : "";
+      if (typeof entity !== "string") {
+        entityMarker.entityColor = entity.color;
+      }
+
       // create marker with the icon
       const marker = Leaflet.marker([latitude, longitude], {
         icon: Leaflet.divIcon({
-          html: `
-              <ha-entity-marker
-                entity-id="${getEntityId(entity)}"
-                entity-name="${entityName}"
-                entity-icon="${entityIcon}"
-                entity-picture="${
-                  !(typeof entity !== "string" && entity.label_mode) &&
-                  entityPicture
-                    ? this.hass.hassUrl(entityPicture)
-                    : ""
-                }"
-                ${
-                  typeof entity !== "string"
-                    ? `entity-color="${entity.color}"`
-                    : ""
-                }
-              ></ha-entity-marker>
-            `,
+          html: entityMarker,
           iconSize: [48, 48],
           className: "",
         }),

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -44,7 +44,7 @@ interface MapEntityConfig extends EntityConfig {
 
 interface GeoEntity {
   entity_id: string;
-  display_mode: "icon" | undefined;
+  label_mode?: "state" | "name" | "icon";
   focus: boolean;
 }
 
@@ -352,7 +352,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       ) {
         geoEntities.push({
           entity_id: stateObj.entity_id,
-          display_mode: sourceObj?.display_mode ?? allSource?.display_mode,
+          label_mode: sourceObj?.label_mode ?? allSource?.label_mode,
           focus: sourceObj
             ? (sourceObj.focus ?? true)
             : (allSource?.focus ?? true),

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -44,6 +44,7 @@ interface MapEntityConfig extends EntityConfig {
 
 interface GeoEntity {
   entity_id: string;
+  display_mode: "icon" | undefined;
   focus: boolean;
 }
 
@@ -351,6 +352,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       ) {
         geoEntities.push({
           entity_id: stateObj.entity_id,
+          display_mode: sourceObj?.display_mode ?? allSource?.display_mode,
           focus: sourceObj
             ? (sourceObj.focus ?? true)
             : (allSource?.focus ?? true),
@@ -370,8 +372,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
         name: entityConf.name,
       })),
       ...this._getSourceEntities(this.hass?.states).map((entity) => ({
-        entity_id: entity.entity_id,
-        focus: entity.focus,
+        ...entity,
         color: this._getColor(entity.entity_id),
       })),
     ];

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -304,6 +304,7 @@ export interface LogbookCardConfig extends LovelaceCardConfig {
 
 interface GeoLocationSourceConfig {
   source: string;
+  display_mode?: "icon";
   focus?: boolean;
 }
 

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -304,7 +304,7 @@ export interface LogbookCardConfig extends LovelaceCardConfig {
 
 interface GeoLocationSourceConfig {
   source: string;
-  display_mode?: "icon";
+  label_mode?: "name" | "state" | "icon";
   focus?: boolean;
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -48,7 +48,7 @@ export const mapEntitiesConfigStruct = union([
 const geoSourcesConfigStruct = union([
   object({
     source: string(),
-    display_mode: optional(string()),
+    label_mode: optional(string()),
     focus: optional(boolean()),
   }),
   string(),

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -48,6 +48,7 @@ export const mapEntitiesConfigStruct = union([
 const geoSourcesConfigStruct = union([
   object({
     source: string(),
+    display_mode: optional(string()),
     focus: optional(boolean()),
   }),
   string(),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Add a mode to show geolocation entities on the map as icons instead of their current name. The current behavior seems to just produce an unintelligible letter-salad, so I think seeing the icons would be quite a bit cleaner. Perhaps it should even be made the default mode, but for now it's just backward-compatible optional mode. Most geolocation sources I've seen tend to include a nice icon as part of the entity (typically for natural disasters).

Current:
![image](https://github.com/user-attachments/assets/ed663a47-78a7-4c53-8266-92f5ae4558db)


Proposed:
![image](https://github.com/user-attachments/assets/fef5dbd1-5f4d-45f1-89d4-66048876789a)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
