### PR TITLE
Remove not needed admin checks

### DIFF
--- a/src/panels/lovelace/editor/select-dashboard/hui-dialog-select-dashboard.ts
+++ b/src/panels/lovelace/editor/select-dashboard/hui-dialog-select-dashboard.ts
@@ -140,9 +140,7 @@ export class HuiDialogSelectDashboard extends LitElement {
         mode: this.hass.panels.lovelace?.config?.mode,
       },
       ...(this._params!.dashboards || (await fetchDashboards(this.hass))),
-    ].filter(
-      (dashboard) => this.hass.user!.is_admin || !dashboard.require_admin
-    );
+    ];
 
     const currentPath = this._fromUrlPath || this.hass.defaultPanel;
     for (const dashboard of this._dashboards!) {

--- a/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
+++ b/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
@@ -90,18 +90,15 @@ export class HuiDialogSelectView extends LitElement {
               >
                 Default
               </mwc-list-item>
-              ${this._dashboards.map((dashboard) => {
-                if (!this.hass.user!.is_admin && dashboard.require_admin) {
-                  return "";
-                }
-                return html`
+              ${this._dashboards.map(
+                (dashboard) => html`
                   <mwc-list-item
                     .disabled=${dashboard.mode !== "storage"}
                     .value=${dashboard.url_path}
                     >${dashboard.title}</mwc-list-item
                   >
-                `;
-              })}
+                `
+              )}
             </ha-select>`
           : ""}
         ${!this._config || (this._config.views || []).length < 1


### PR DESCRIPTION
## Proposed change
- remove isAdmin checks from move card and move view
  - A non admin user isn't able to edit a dashboard at all, so he/she won't be able to move anything around

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
