### PR TITLE
Fix `navigate` with replace when there are open dialogs

### DIFF
--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -177,9 +177,9 @@ export const closeLastDialog = async () => {
 };
 
 export const closeAllDialogs = async () => {
-  while (OPEN_DIALOG_STACK.length) {
+  for (let i = OPEN_DIALOG_STACK.length - 1; i >= 0; i--) {
     // eslint-disable-next-line no-await-in-loop
-    const closed = await closeLastDialog();
+    const closed = await closeDialog(OPEN_DIALOG_STACK[i].dialogTag);
     if (!closed) {
       return false;
     }
@@ -187,7 +187,7 @@ export const closeAllDialogs = async () => {
   return true;
 };
 
-const _handleClosed = async (ev: HASSDomEvent<DialogClosedParams>) => {
+const _handleClosed = (ev: HASSDomEvent<DialogClosedParams>) => {
   // If not closed by navigating back, remove the open state from history
   const dialogIndex = OPEN_DIALOG_STACK.findIndex(
     (state) => state.dialogTag === ev.detail.dialog


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This should fix the [replace case](https://github.com/home-assistant/frontend/pull/23262#issuecomment-2536798339). `closeDialog` may be called multiple times on some dialogs but this won't cause extra `back()` calls.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
