### PR TITLE
For consistency align close button to the left in `ha-dialog`

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -15,13 +15,13 @@ export const createCloseHeading = (
   title: string | TemplateResult
 ) => html`
   <div class="header_title">
-    <span>${title}</span>
     <ha-icon-button
       .label=${hass?.localize("ui.dialogs.generic.close") ?? "Close"}
       .path=${mdiClose}
       dialogAction="close"
       class="header_button"
     ></ha-icon-button>
+    <span>${title}</span>
   </div>
 `;
 
@@ -102,7 +102,10 @@ export class HaDialog extends DialogBase {
         align-items: var(--vertical-align-dialog, center);
       }
       .mdc-dialog__title {
-        padding: 24px 24px 0 24px;
+        padding: 12px 12px 0;
+      }
+      .mdc-dialog--scrollable .mdc-dialog__title {
+        padding: 12px;
       }
       .mdc-dialog__actions {
         padding: 12px 24px 12px 24px;
@@ -138,10 +141,8 @@ export class HaDialog extends DialogBase {
         flex-direction: column;
       }
       .header_title {
-        position: relative;
-        padding-right: 40px;
-        padding-inline-end: 40px;
-        padding-inline-start: initial;
+        display: flex;
+        align-items: center;
         direction: var(--direction);
       }
       .header_title span {
@@ -149,11 +150,9 @@ export class HaDialog extends DialogBase {
         text-overflow: ellipsis;
         white-space: nowrap;
         display: block;
+        padding-left: 4px;
       }
       .header_button {
-        position: absolute;
-        right: -12px;
-        top: -12px;
         text-decoration: none;
         color: inherit;
         inset-inline-start: initial;


### PR DESCRIPTION
## Proposed change
For consistency reasons this PR aligns the close button to the left for dialogs that use `createCloseHeading` of `ha-dialorg`.

| <img width="615" alt="image" src="https://github.com/user-attachments/assets/4a2b1885-ed49-4589-ba09-52c42b621477" /> | <img width="510" alt="image" src="https://github.com/user-attachments/assets/d74fb610-978e-469e-98db-440095ded68b" /> |
|:-:|:-:|

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
