### PR TITLE
Add 'any known state' as an option for state trigger

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -91,6 +91,8 @@ export interface StateTrigger extends BaseTrigger {
   attribute?: string;
   from?: string | string[];
   to?: string | string[];
+  not_from?: string | string[];
+  not_to?: string | string[];
   for?: string | number | ForDict;
 }
 

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -319,7 +319,9 @@ const tryDescribeTrigger = (
     if (
       !trigger.attribute &&
       trigger.from === undefined &&
-      trigger.to === undefined
+      trigger.to === undefined &&
+      trigger.not_from === undefined &&
+      trigger.not_to === undefined
     ) {
       toChoice = "special";
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3133,6 +3133,7 @@
                   "for": "For",
                   "to": "To (optional)",
                   "any_state_ignore_attributes": "Any state (ignoring attribute changes)",
+                  "any_known_state": "Any known state (excluding unavailable/unknown)",
                   "description": {
                     "picker": "When the state of an entity (or attribute) changes.",
                     "full": "When{hasAttribute, select, \n true { {attribute} of} \n other {}\n} {hasEntity, select, \n true {{entity}} \n other {something}\n} changes{fromChoice, select, \n fromUsed { from {fromString}}\n null { from any state} \n other {}\n}{toChoice, select, \n toUsed { to {toString}} \n null { to any state} \n special { state or any attributes} \n other {}\n}{hasDuration, select, \n true { for {duration}} \n other {}\n}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
In the to/from box for state trigger, add "Any known state" as an option, which is equivalent to adding `not_to: ['unavailable', 'unknown']` in the YAML.

This is intended to make things like event entities a little more user friendly, as to write any state trigger for an event entity I almost consider it a requirement to add the following, lest spurious and unexpected triggers be generated, and it's a little uncomfortable that doing so is currently possible in YAML only. 

```yaml
not_to: 
  - unavailable 
  - unknown
not_from:
  - unavailable
  - unknown
```

![image](https://github.com/user-attachments/assets/735b294b-cdc6-4305-a05f-fdfccd1e667d)




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/wth-why-is-ignoring-unknown-unavailable-states-so-difficult/809914
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
