### PR TITLE
Make Device Condition description consistent with Trigger and Action

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3351,7 +3351,7 @@
                   "label": "Device",
                   "condition": "Condition",
                   "description": {
-                    "picker": "Set of conditions provided by your device. Great way to start."
+                    "picker": "Set of conditions provided by a device. Great way to start."
                   }
                 },
                 "not": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The first item in the lists of the Triggers, Conditions and Actions is always the Device type:

- When something happens to **a** device. Great way to start.
- Set of conditions provided by **your** device. Great way to start.
- Do something on **a** device. Great way to start.

The condition does use "your" instead of "a" which is inconsistent and sounds irritating. As there are usually many different devices in a setup the use of "a" is much preferred as the actual device is picked up at the next step.

This small PR makes the condition string consistent by replacing "your" with "a".

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
