### PR TITLE
Disable backup by default for update more info

### DIFF
--- a/src/dialogs/more-info/controls/more-info-update.ts
+++ b/src/dialogs/more-info/controls/more-info-update.ts
@@ -146,7 +146,6 @@ class MoreInfoUpdate extends LitElement {
                 </span>
                 <ha-switch
                   id="create-backup"
-                  checked
                   .disabled=${updateIsInstalling(this.stateObj)}
                 ></ha-switch>
               </ha-settings-row>
@@ -234,7 +233,7 @@ class MoreInfoUpdate extends LitElement {
     if (createBackupSwitch) {
       return createBackupSwitch.checked;
     }
-    return true;
+    return false;
   }
 
   private _handleInstall(): void {


### PR DESCRIPTION
## Breaking change

Backup are now disabled by default when updating with the more info dialog.

## Proposed change

Disable backup by default for update more info as we now have scheduled backup.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
