### PR TITLE
Focus on card search input when adding new card

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -65,6 +65,8 @@ export class HuiCardPicker extends LitElement {
 
   @state() private _height?: number;
 
+  @state() private _narrow = false;
+
   private _unusedEntities?: string[];
 
   private _usedEntities?: string[];
@@ -132,6 +134,7 @@ export class HuiCardPicker extends LitElement {
     return html`
       <search-input
         .hass=${this.hass}
+        dialogInitialFocus
         .filter=${this._filter}
         @value-changed=${this._handleSearchChange}
         .label=${this.hass.localize(

--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -69,6 +69,16 @@ export class HuiCardPicker extends LitElement {
 
   private _usedEntities?: string[];
 
+  public async focus(): Promise<void> {
+    const searchInput = this.renderRoot.querySelector("search-input");
+    if (searchInput) {
+      searchInput.focus();
+    } else {
+      await this.updateComplete;
+      this.focus();
+    }
+  }
+
   private _filterCards = memoizeOne(
     (cardElements: CardElement[], filter?: string): CardElement[] => {
       if (!filter) {
@@ -132,7 +142,6 @@ export class HuiCardPicker extends LitElement {
     return html`
       <search-input
         .hass=${this.hass}
-        dialogInitialFocus
         .filter=${this._filter}
         @value-changed=${this._handleSearchChange}
         .label=${this.hass.localize(

--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -65,8 +65,6 @@ export class HuiCardPicker extends LitElement {
 
   @state() private _height?: number;
 
-  @state() private _narrow = false;
-
   private _unusedEntities?: string[];
 
   private _usedEntities?: string[];

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -3,6 +3,7 @@ import "@material/mwc-tab/mwc-tab";
 import { mdiClose } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
+import { ifDefined } from "lit/directives/if-defined";
 import { customElement, property, state } from "lit/decorators";
 import { cache } from "lit/directives/cache";
 import { classMap } from "lit/directives/class-map";
@@ -60,8 +61,14 @@ export class HuiCreateDialogCard
 
   @state() private _currTabIndex = 0;
 
+  @state() private _narrow = false;
+
   public async showDialog(params: CreateCardDialogParams): Promise<void> {
     this._params = params;
+
+    this._narrow = matchMedia(
+      "all and (max-width: 450px), all and (max-height: 500px)"
+    ).matches;
 
     const containerConfig = findLovelaceContainer(
       params.lovelaceConfig,
@@ -120,6 +127,7 @@ export class HuiCreateDialogCard
               .label=${this.hass!.localize(
                 "ui.panel.lovelace.editor.cardpicker.by_card"
               )}
+              dialogInitialFocus=${ifDefined(this._narrow ? "" : undefined)}
             ></mwc-tab>
             <mwc-tab
               .label=${this.hass!.localize(
@@ -132,7 +140,7 @@ export class HuiCreateDialogCard
           this._currTabIndex === 0
             ? html`
                 <hui-card-picker
-                  dialogInitialFocus
+                  dialogInitialFocus=${ifDefined(this._narrow ? undefined : "")}
                   .suggestedCards=${this._params.suggestedCards}
                   .lovelace=${this._params.lovelaceConfig}
                   .hass=${this.hass}

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -120,7 +120,6 @@ export class HuiCreateDialogCard
               .label=${this.hass!.localize(
                 "ui.panel.lovelace.editor.cardpicker.by_card"
               )}
-              dialogInitialFocus
             ></mwc-tab>
             <mwc-tab
               .label=${this.hass!.localize(
@@ -133,6 +132,7 @@ export class HuiCreateDialogCard
           this._currTabIndex === 0
             ? html`
                 <hui-card-picker
+                  dialogInitialFocus
                   .suggestedCards=${this._params.suggestedCards}
                   .lovelace=${this._params.lovelaceConfig}
                   .hass=${this.hass}
@@ -143,7 +143,7 @@ export class HuiCreateDialogCard
                 <hui-entity-picker-table
                   no-label-float
                   .hass=${this.hass}
-                  .narrow=${true}
+                  narrow
                   .entities=${this._allEntities(this.hass.states)}
                   @selected-changed=${this._handleSelectedChanged}
                 ></hui-entity-picker-table>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.


## Proposed change
- set focus to "Search cards" input when opening the <hui-dialog-create-card> to search cards faster

## Type of change
- [x] UX quality of life improvement
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- Please verify if it works properly on mobile.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
