### PR TITLE
Cloud login: Wait with navigate until confirm action is done

### DIFF
--- a/src/panels/config/cloud/login/cloud-login.ts
+++ b/src/panels/config/cloud/login/cloud-login.ts
@@ -233,7 +233,6 @@ export class CloudLogin extends LitElement {
     const doLogin = async (username: string) => {
       try {
         const result = await cloudLogin(this.hass, username, password);
-        fireEvent(this, "ha-refresh-cloud-status");
         this.email = "";
         this._password = "";
         if (result.cloud_pipeline) {
@@ -250,6 +249,7 @@ export class CloudLogin extends LitElement {
             setAssistPipelinePreferred(this.hass, result.cloud_pipeline);
           }
         }
+        fireEvent(this, "ha-refresh-cloud-status");
       } catch (err: any) {
         const errCode = err && err.body && err.body.code;
         if (errCode === "PasswordChangeRequired") {


### PR DESCRIPTION


## Proposed change

We would navigate to the account page page when login in to cloud while there could be a dialog open. We now wait for the dialog to be handled before we navigate.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
