### PR TITLE
Sortable energy individual devices

### DIFF
--- a/src/panels/config/energy/components/ha-energy-device-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-device-settings.ts
@@ -1,12 +1,15 @@
 import "@material/mwc-button/mwc-button";
 import { mdiDelete, mdiDevices, mdiPencil } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { html, LitElement } from "lit";
+import { css, html, LitElement } from "lit";
+import { repeat } from "lit/directives/repeat";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-card";
 import "../../../../components/ha-icon-button";
 import "../../../../components/ha-state-icon";
+import "../../../../components/ha-sortable";
+import "../../../../components/ha-svg-icon";
 import type {
   DeviceConsumptionEnergyPreference,
   EnergyPreferences,
@@ -38,6 +41,16 @@ export class EnergyDeviceSettings extends LitElement {
 
   @property({ attribute: false })
   public validationResult?: EnergyPreferencesValidation;
+
+  private _deviceKeys = new WeakMap<any, string>();
+
+  private _getKey(device) {
+    if (!this._deviceKeys.has(device)) {
+      this._deviceKeys.set(device, Math.random().toString());
+    }
+
+    return this._deviceKeys.get(device)!;
+  }
 
   protected render(): TemplateResult {
     return html`
@@ -79,36 +92,44 @@ export class EnergyDeviceSettings extends LitElement {
               "ui.panel.config.energy.device_consumption.devices"
             )}
           </h3>
-          ${this.preferences.device_consumption.map((device) => {
-            const entityState = this.hass.states[device.stat_consumption];
-            return html`
-              <div class="row" .device=${device}>
-                <ha-state-icon
-                  .hass=${this.hass}
-                  .stateObj=${entityState}
-                ></ha-state-icon>
-                <span class="content"
-                  >${device.name ||
-                  getStatisticLabel(
-                    this.hass,
-                    device.stat_consumption,
-                    this.statsMetadata?.[device.stat_consumption]
-                  )}</span
-                >
-                <ha-icon-button
-                  .label=${this.hass.localize("ui.common.edit")}
-                  @click=${this._editDevice}
-                  .path=${mdiPencil}
-                ></ha-icon-button>
-                <ha-icon-button
-                  .label=${this.hass.localize("ui.common.delete")}
-                  @click=${this._deleteDevice}
-                  .device=${device}
-                  .path=${mdiDelete}
-                ></ha-icon-button>
-              </div>
-            `;
-          })}
+          <ha-sortable handle-selector=".row" @item-moved=${this._itemMoved}>
+            <div class="devices">
+              ${repeat(
+                this.preferences.device_consumption,
+                (device) => this._getKey(device),
+                (device) => {
+                  const entityState = this.hass.states[device.stat_consumption];
+                  return html`
+                    <div class="row" .device=${device}>
+                      <ha-state-icon
+                        .hass=${this.hass}
+                        .stateObj=${entityState}
+                      ></ha-state-icon>
+                      <span class="content"
+                        >${device.name ||
+                        getStatisticLabel(
+                          this.hass,
+                          device.stat_consumption,
+                          this.statsMetadata?.[device.stat_consumption]
+                        )}</span
+                      >
+                      <ha-icon-button
+                        .label=${this.hass.localize("ui.common.edit")}
+                        @click=${this._editDevice}
+                        .path=${mdiPencil}
+                      ></ha-icon-button>
+                      <ha-icon-button
+                        .label=${this.hass.localize("ui.common.delete")}
+                        @click=${this._deleteDevice}
+                        .device=${device}
+                        .path=${mdiDelete}
+                      ></ha-icon-button>
+                    </div>
+                  `;
+                }
+              )}
+            </div>
+          </ha-sortable>
           <div class="row">
             <ha-svg-icon .path=${mdiDevices}></ha-svg-icon>
             <mwc-button @click=${this._addDevice}
@@ -120,6 +141,21 @@ export class EnergyDeviceSettings extends LitElement {
         </div>
       </ha-card>
     `;
+  }
+
+  private _itemMoved(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const { oldIndex, newIndex } = ev.detail;
+    const devices = this.preferences.device_consumption.concat();
+    const device = devices.splice(oldIndex, 1)[0];
+    devices.splice(newIndex, 0, device);
+
+    const newPrefs = {
+      ...this.preferences,
+      device_consumption: devices,
+    };
+    fireEvent(this, "value-changed", { value: newPrefs });
+    this._savePreferences(newPrefs);
   }
 
   private _editDevice(ev) {
@@ -184,7 +220,16 @@ export class EnergyDeviceSettings extends LitElement {
   }
 
   static get styles(): CSSResultGroup {
-    return [haStyle, energyCardStyles];
+    return [
+      haStyle,
+      energyCardStyles,
+      css`
+        .row {
+          cursor: move; /* fallback if grab cursor is unsupported */
+          cursor: grab;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/config/energy/components/ha-energy-device-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-device-settings.ts
@@ -42,16 +42,6 @@ export class EnergyDeviceSettings extends LitElement {
   @property({ attribute: false })
   public validationResult?: EnergyPreferencesValidation;
 
-  private _deviceKeys = new WeakMap<any, string>();
-
-  private _getKey(device) {
-    if (!this._deviceKeys.has(device)) {
-      this._deviceKeys.set(device, Math.random().toString());
-    }
-
-    return this._deviceKeys.get(device)!;
-  }
-
   protected render(): TemplateResult {
     return html`
       <ha-card outlined>
@@ -96,7 +86,7 @@ export class EnergyDeviceSettings extends LitElement {
             <div class="devices">
               ${repeat(
                 this.preferences.device_consumption,
-                (device) => this._getKey(device),
+                (device) => device.stat_consumption,
                 (device) => {
                   const entityState = this.hass.states[device.stat_consumption];
                   return html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Make the energy devices settings rows drag/drop sortable. It doesn't offer too much benefit, but it does affect the color of the devices, and maybe people want to organize their lists in a certain way for better visibility or something.

Often requested:
https://community.home-assistant.io/t/energy-management-reorganize-individual-devices/342280
https://community.home-assistant.io/t/wth-cant-i-reorder-devices-in-the-energy-dashboard/471502
https://community.home-assistant.io/t/wth-is-in-energy-dashboard-the-individual-devices-not-able-to-reorder/805051

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
