### PR TITLE
Wrong lowercase and adjacent space in dialog-media-manage.ts

### DIFF
--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -211,7 +211,7 @@ class DialogMediaManage extends LitElement {
                     @click=${this.closeDialog}
                   >
                     ${this.hass.localize(
-                        "ui.components.media-browser.file_management.tip_storage_panel"
+                      "ui.components.media-browser.file_management.tip_storage_panel"
                     )}
                   </a>`,
                 }

--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -210,11 +210,9 @@ class DialogMediaManage extends LitElement {
                     href="/config/storage"
                     @click=${this.closeDialog}
                   >
-                    ${this.hass
-                      .localize(
+                    ${this.hass.localize(
                         "ui.components.media-browser.file_management.tip_storage_panel"
-                      )
-                    }
+                    )}
                   </a>`,
                 }
               )}

--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -214,7 +214,7 @@ class DialogMediaManage extends LitElement {
                       .localize(
                         "ui.components.media-browser.file_management.tip_storage_panel"
                       )
-                      .toLowerCase()}
+                    }
                   </a>`,
                 }
               )}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -935,7 +935,7 @@
           "delete": "Delete {count}",
           "deleting": "Deleting {count}",
           "tip_media_storage": "[%key:ui::panel::config::tips::media_storage%]",
-          "tip_storage_panel": "[%key:ui::panel::config::storage::caption%]"
+          "tip_storage_panel": "storage"
         },
         "class": {
           "album": "Album",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The Tip in the Media management dialog contains a link to the Storage panel which has two issues:

![Screenshot 2024-10-18 15 19 06](https://github.com/user-attachments/assets/13b67106-362a-4361-8007-4a6da051a00d)

- The word "storage" should not be forced to lowercase as it can be a capitalized noun in some translations
- The link extends to the space character to the right of the word.

This PR removes the forced lowercase and the overlapping space by fixing the excessive indentation inside the HTML code block and  changes "storage" to lowercase in en.json instead.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22431 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
