### PR TITLE
Show all disabled helpers in config/helpers

### DIFF
--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -192,7 +192,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
 
   @state() private _stateItems: HassEntity[] = [];
 
-  @state() private _disabledEntries?: EntityRegistryEntry[];
+  @state() private _disabledEntityEntries?: EntityRegistryEntry[];
 
   @state() private _entityEntries?: Record<string, EntityRegistryEntry>;
 
@@ -505,6 +505,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
         configEntry: undefined,
         entity: undefined,
         selectable: true,
+        disabled: true,
       }));
 
       return [...states, ...entries, ...disabledItems]
@@ -622,7 +623,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
     const helpers = this._getItems(
       this.hass.localize,
       this._stateItems,
-      this._disabledEntries || [],
+      this._disabledEntityEntries || [],
       this._entityEntries,
       this._configEntries,
       this._entityReg,
@@ -882,7 +883,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
               ?.labels.some((lbl) => filter.includes(lbl))
           )
           .forEach((stateItem) => labelItems.add(stateItem.entity_id));
-        (this._disabledEntries || [])
+        (this._disabledEntityEntries || [])
           .filter((entry) => entry.labels.some((lbl) => filter.includes(lbl)))
           .forEach((entry) => labelItems.add(entry.entity_id));
         if (!items) {
@@ -910,7 +911,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
               )?.categories.helpers
           )
           .forEach((stateItem) => categoryItems.add(stateItem.entity_id));
-        (this._disabledEntries || [])
+        (this._disabledEntityEntries || [])
           .filter((entry) => filter[0] === entry.categories.helpers)
           .forEach((entry) => categoryItems.add(entry.entity_id));
         if (!items) {
@@ -1141,7 +1142,7 @@ ${rejected
         changedProps.has("_configEntries")) &&
       this._helperManifests
     ) {
-      this._disabledEntries = Object.values(this._entityEntries).filter(
+      this._disabledEntityEntries = Object.values(this._entityEntries).filter(
         (e) =>
           e.disabled_by &&
           (e.platform in this._helperManifests! ||


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Fix inconsistent behavior for disabled helpers; current behavior is that disabled helpers created in UI are shown, but disabled helpers created in YAML are not shown. 

This change makes it so that all disabled helpers are shown.

Also for the disabled entities that are currently shown, they don't work right for filtering. They can have labels & categories, but if you apply any label/category filter, they never pass the filter even when they should. This change fixes the filtering on disabled helpers.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
