### PR TITLE
Use null instead of default, to avoid stomping on netmask

### DIFF
--- a/src/data/hassio/network.ts
+++ b/src/data/hassio/network.ts
@@ -117,11 +117,10 @@ export const accesspointScan = async (
 };
 
 export const parseAddress = (address: string) => {
-  const isIPv6 = address.includes(":");
-  const [ip, cidr] = address.includes("/")
-    ? address.split("/")
-    : [address, isIPv6 ? "64" : "24"];
-  return { ip, mask: cidrToNetmask(cidr, isIPv6) };
+  const [ip, cidr] = address.split("/");
+  const isIPv6 = ip.includes(":");
+  const mask = cidr ? cidrToNetmask(cidr, isIPv6) : null;
+  return { ip, mask };
 };
 
 export const formatAddress = (ip: string, mask: string) =>

--- a/src/panels/config/network/supervisor-network.ts
+++ b/src/panels/config/network/supervisor-network.ts
@@ -655,8 +655,14 @@ export class HassioNetwork extends LitElement {
     this._dirty = true;
     if (id === "address") {
       const index = (ev.target as any).index as number;
+      const { mask: oldMask } = parseAddress(
+        this._interface![version]!.address![index]
+      );
       const { mask } = parseAddress(value);
-      this._interface[version]!.address![index] = formatAddress(value, mask);
+      this._interface[version]!.address![index] = formatAddress(
+        value,
+        mask || oldMask || ""
+      );
       this.requestUpdate("_interface");
     } else if (id === "netmask") {
       const index = (ev.target as any).index as number;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Refines https://github.com/home-assistant/frontend/pull/23348 to return `null` instead of a default netmask. This then allows the code to avoid stomping on a preexisting netmask that isn't /24 for IPv4 or /64 for IPv6.

To be clear, the issue was never that the default was wrong, but that the netmask is overwritten as soon as the IP address field blurs, and the previous PR doesn't change that. A user tweaking the last octet of their IP address and clicking Save will not have the opportunity to notice the changed netmask before it applies and they lose access. /24 is less likely to break things but people do use /25s and 10.x.x.x networks. And /64 is the smallest used subnet for IPv6, /48 is quite often given out by ISPs.

This PR also switches to checking `ip` for colons instead of the whole `address` field, but that's very minor as nothing's validated at this stage.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23347, #23246
- This PR is related to issue or discussion: #23348
- Link to documentation pull request:

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
