### PR TITLE
Make quotation marks localizable in Add badge dialog

### DIFF
--- a/src/panels/lovelace/editor/badge-editor/hui-dialog-create-badge.ts
+++ b/src/panels/lovelace/editor/badge-editor/hui-dialog-create-badge.ts
@@ -81,7 +81,7 @@ export class HuiCreateDialogBadge
     const title = this._containerConfig.title
       ? this.hass!.localize(
           "ui.panel.lovelace.editor.edit_badge.pick_badge_title",
-          { name: `"${this._containerConfig.title}"` }
+          { name: this._containerConfig.title }
         )
       : this.hass!.localize("ui.panel.lovelace.editor.edit_badge.pick_badge");
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6048,7 +6048,7 @@
             "header": "Badge configuration",
             "typed_header": "{type} Badge configuration",
             "pick_badge": "Which badge would you like to add?",
-            "pick_badge_title": "Which badge would you like to add to {name}",
+            "pick_badge_title": "Which badge would you like to add to \"{name}\"?",
             "toggle_editor": "[%key:ui::panel::lovelace::editor::edit_card::toggle_editor%]",
             "unsaved_changes": "[%key:ui::panel::lovelace::editor::edit_card::unsaved_changes%]",
             "confirm_cancel": "[%key:ui::panel::lovelace::editor::edit_card::confirm_cancel%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently the quotation marks in this message are hard-coded:

![image](https://github.com/user-attachments/assets/f09ed797-f4e6-43f5-a583-1219fe6fa14b)

This PR removes them from the code and puts them into the strings file instead for proper localization.
In addition it adds the missing question mark at the end.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23379 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
