### PR TITLE
Improve explanation of passive zones

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4491,7 +4491,7 @@
             "latitude": "Latitude",
             "longitude": "Longitude",
             "passive": "Passive",
-            "passive_note": "Passive zones are hidden in the frontend and are not used as location for device trackers. This is useful if you just want to use it for automations.",
+            "passive_note": "Passive zones are hidden in the frontend and not shown as a location of people or device trackers. This is useful if you just want to use them for automations.",
             "required_error_msg": "This field is required",
             "delete": "Delete",
             "create": "Create",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently the explanation for passive zones says that they "are **not used** as location for device trackers" which contradicts the second sentence that says: "This is useful if you **just** want to **use** it for automations.

![image](https://github.com/user-attachments/assets/14c37e86-277c-47e8-84f3-fb656fe967b5)

So the first sentence says that they are **not used** while the second says they are **just used** for automations.

This PR clarifies that by changing the first sentence to "not shown as" and adds people beside device trackers because (active) zone names show up as the state of people, too.

In addition it fixes the plural / singular mismatch between the two sentences.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
