### PR TITLE
Fix misleading use of "hidden" and "not shown" for disabled entities

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -107,7 +107,7 @@ export class HaDeviceEntitiesCard extends LitElement {
                 ? html`
                     <button class="show-more" @click=${this._toggleShowHidden}>
                       ${this.hass.localize(
-                        "ui.panel.config.devices.entities.hidden_entities",
+                        "ui.panel.config.devices.entities.disabled_entities",
                         { count: hiddenEntities.length }
                       )}
                     </button>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4333,7 +4333,7 @@
             "show_less": "Show less",
             "disabled_entities": "+{count} disabled {count, plural,\n  one {entity}\n  other {entities}\n}",
             "hidden": "Hidden"
-          }
+          },
           "confirm_rename_entity_ids": "Do you also want to rename the entity IDs of your entities?",
           "confirm_rename_entity_ids_warning": "This will not change any configuration (like automations, scripts, scenes, dashboards) that is currently using these entities! You will have to manually edit them yourself to use the new entity IDs!",
           "confirm_rename_entity_will_rename": "{count} {count, plural,\n  one {entity ID}\n  other {entity IDs}\n} will be renamed",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4331,9 +4331,9 @@
             "add_entities_lovelace": "Add to dashboard",
             "none": "This device has no entities",
             "show_less": "Show less",
-            "hidden_entities": "+{count} {count, plural,\n  one {entity}\n  other {entities}\n} not shown",
+            "disabled_entities": "+{count} disabled {count, plural,\n  one {entity}\n  other {entities}\n}",
             "hidden": "Hidden"
-          },
+          }
           "confirm_rename_entity_ids": "Do you also want to rename the entity IDs of your entities?",
           "confirm_rename_entity_ids_warning": "This will not change any configuration (like automations, scripts, scenes, dashboards) that is currently using these entities! You will have to manually edit them yourself to use the new entity IDs!",
           "confirm_rename_entity_will_rename": "{count} {count, plural,\n  one {entity ID}\n  other {entity IDs}\n} will be renamed",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Entities can be just hidden (by turning off "Visible") or completely disabled (by turning off "Enabled"). For hidden entities this is added to the entity name in the Device info page, disabled entities are moved into the collapsed "not shown" section:

![image](https://github.com/user-attachments/assets/b46a0f1d-ef8f-46b7-94c7-761ad44d07ff)

Unfortunately the strings file uses the very misleading key "hidden_entities" for the count of disabled entities plus those words "not shown" which also sound much more like "hidden" instead of "disabled".

_This results in many completely wrong translations of "not shown" as "hidden". It was the case in German, it still is in Dutch ("entiteiten verborgen") or Italian ("entità nascoste"), e.g._

![Screenshot 2024-12-25 09 40 04](https://github.com/user-attachments/assets/c24321e5-65e1-4674-a519-7475fa0d72a5)

This PR fixes this by using "disabled" for both the key and in the link shown in the above section. This will automatically remove the wrong use of "hidden" here in all translations.

_Personal note: I was completely confused when I started with Home Assistant in German because of that wrong translation of "not shown" as "hidden". It cost me a considerable amount of time to figure out that this was just a misleading wording here and "hidden" entities don't land in that section._

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
