### PR TITLE
Add missing localizations for Voice Assistants > Expose headers

### DIFF
--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -146,6 +146,9 @@ export class VoiceAssistantsExpose extends LitElement {
     ): DataTableColumnContainer => ({
       icon: {
         title: "",
+        label: localize(
+          "ui.panel.config.voice_assistants.expose.headers.icon"
+        ),
         type: "icon",
         moveable: false,
         hidden: narrow,
@@ -241,6 +244,9 @@ export class VoiceAssistantsExpose extends LitElement {
       },
       remove: {
         title: "",
+        label: localize(
+          "ui.panel.config.voice_assistants.expose.headers.remove"
+        ),
         type: "icon-button",
         hidden: narrow,
         template: () =>

--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -146,7 +146,9 @@ export class VoiceAssistantsExpose extends LitElement {
     ): DataTableColumnContainer => ({
       icon: {
         title: "",
-        label: localize("ui.panel.config.voice_assistants.expose.headers.icon"),
+        label: localize(
+          "ui.panel.config.voice_assistants.expose.headers.icon"
+        ),
         type: "icon",
         moveable: false,
         hidden: narrow,
@@ -160,7 +162,9 @@ export class VoiceAssistantsExpose extends LitElement {
       },
       name: {
         main: true,
-        title: localize("ui.panel.config.voice_assistants.expose.headers.name"),
+        title: localize(
+          "ui.panel.config.voice_assistants.expose.headers.name"
+        ),
         sortable: true,
         filterable: true,
         direction: "asc",

--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -146,9 +146,7 @@ export class VoiceAssistantsExpose extends LitElement {
     ): DataTableColumnContainer => ({
       icon: {
         title: "",
-        label: localize(
-          "ui.panel.config.voice_assistants.expose.headers.icon"
-        ),
+        label: localize("ui.panel.config.voice_assistants.expose.headers.icon"),
         type: "icon",
         moveable: false,
         hidden: narrow,
@@ -244,9 +242,7 @@ export class VoiceAssistantsExpose extends LitElement {
       },
       remove: {
         title: "",
-        label: localize(
-          "ui.panel.config.voice_assistants.expose.headers.remove"
-        ),
+        label: localize("ui.panel.config.voice_assistants.expose.headers.remove"),
         type: "icon-button",
         hidden: narrow,
         template: () =>

--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -242,7 +242,9 @@ export class VoiceAssistantsExpose extends LitElement {
       },
       remove: {
         title: "",
-        label: localize("ui.panel.config.voice_assistants.expose.headers.remove"),
+        label: localize(
+          "ui.panel.config.voice_assistants.expose.headers.remove"
+        ),
         type: "icon-button",
         hidden: narrow,
         template: () =>

--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -146,9 +146,7 @@ export class VoiceAssistantsExpose extends LitElement {
     ): DataTableColumnContainer => ({
       icon: {
         title: "",
-        label: localize(
-          "ui.panel.config.voice_assistants.expose.headers.icon"
-        ),
+        label: localize("ui.panel.config.voice_assistants.expose.headers.icon"),
         type: "icon",
         moveable: false,
         hidden: narrow,
@@ -162,9 +160,7 @@ export class VoiceAssistantsExpose extends LitElement {
       },
       name: {
         main: true,
-        title: localize(
-          "ui.panel.config.voice_assistants.expose.headers.name"
-        ),
+        title: localize("ui.panel.config.voice_assistants.expose.headers.name"),
         sortable: true,
         filterable: true,
         direction: "asc",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2826,12 +2826,14 @@
           "expose": {
             "caption": "Expose",
             "headers": {
+              "icon": "Icon",
               "name": "Name",
               "entity_id": "Entity ID",
               "area": "Area",
               "domain": "Domain",
               "assistants": "Assistants",
-              "aliases": "Aliases"
+              "aliases": "Aliases",
+              "remove": "[%key:ui::common::remove%]"
             },
             "aliases": "{count} aliases",
             "expose": "Expose",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The Icon and the Remove columns of the Expose tab for Settings > Voice Assistants are lacking localizable labels so they show up with their lowercase variable names only:

![image](https://github.com/user-attachments/assets/4e2da28c-de6e-4c15-b6a7-f3816184bb78)

This PR adds two string definitions to en.json and the necessary code to ha-config-voice-assistants-expose.ts

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
