### PR TITLE
Fix Energy-Dashboard unexpected Period Calculation

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -401,7 +401,11 @@ const getEnergyData = async (
 
   const dayDifference = differenceInDays(end || new Date(), start);
   const period =
-    dayDifference > 35 ? "month" : dayDifference > 2 ? "day" : "hour";
+    isFirstDayOfMonth(start) && isLastDayOfMonth(end) && dayDifference > 35
+      ? "month"
+      : dayDifference > 2
+        ? "day"
+        : "hour";
 
   const lengthUnit = hass.config.unit_system.length || "";
   const energyUnits: StatisticsUnitConfiguration = {

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -402,7 +402,7 @@ const getEnergyData = async (
   const dayDifference = differenceInDays(end || new Date(), start);
   const period =
     isFirstDayOfMonth(start) &&
-    isLastDayOfMonth(end || new Date()) &&
+    (!end || isLastDayOfMonth(end)) &&
     dayDifference > 35
       ? "month"
       : dayDifference > 2

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -401,7 +401,9 @@ const getEnergyData = async (
 
   const dayDifference = differenceInDays(end || new Date(), start);
   const period =
-    isFirstDayOfMonth(start) && isLastDayOfMonth(end) && dayDifference > 35
+    isFirstDayOfMonth(start) &&
+    isLastDayOfMonth(end || new Date()) &&
+    dayDifference > 35
       ? "month"
       : dayDifference > 2
         ? "day"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
In Energy-Dashboard it is possible to select exact Date Ranges. If there are more than 35 days selected then whole month is used and therefor the Energy-Distribution Calculation totally unexpected for me:
Example: Liked to know how much Grid Energy was used last 365 days and this is not what i expect:
![image](https://github.com/user-attachments/assets/d269b67c-a583-449e-9d77-0439c263156c)

This pull request can still use whole month, but if you select ranges which are not whole month, it uses Days and Energy-Distribution is on day-basis and more correct:
![image](https://github.com/user-attachments/assets/9d031243-6b0f-4303-90fb-83a3f199c7fd)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
