### PR TITLE
Use consistent "More info" for To-do-lists and automations etc.

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3013,7 +3013,7 @@
             "run": "Run actions",
             "rename": "[%key:ui::panel::config::automation::editor::triggers::rename%]",
             "show_trace": "Traces",
-            "show_info": "Information",
+            "show_info": "More info",
             "default_name": "New automation",
             "missing_name": "Cannot save automation without a name",
             "traces_not_available": "Automations need an ID for history to be tracked. Add an ID to your automation to make it available in traces.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7119,7 +7119,7 @@
         "create_list": "Create list",
         "delete_list": "Delete list",
         "add_item": "Add item",
-        "information": "Information",
+        "information": "More info",
         "delete_confirm_title": "Remove {name}?",
         "delete_confirm_text": "Are you sure you want to remove this list and all of its items?",
         "restart_confirm": "Restart Home Assistant to finish removing this to-do list"


### PR DESCRIPTION
When you select "Information" from the three-dot menu of a To-do list or Shopping list

![Screenshot 2024-12-26 15 46 22](https://github.com/user-attachments/assets/676bc82a-a493-4cc0-8a36-f132128c3e9a)

this actually opens the "More info" dialog:

![Screenshot 2024-12-26 15 53 29](https://github.com/user-attachments/assets/1752ef3a-2ad3-4665-a093-7e8de30bd130)

Therefore the menu item needs to use the same consistent term here like we have for Interactions in the Dashboard:

![image](https://github.com/user-attachments/assets/c05a2d6c-15da-4fb7-b9c2-a6ffcf18a6ec)


Edit: The same should be added for the "Information" menu items in Automations, Scenes and Scripts.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Replace "Information" with "More info" for a consistent terminology for
- To do lists
- Automations
- Scenes
- Scripts

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
