### PR TITLE
History: Improve explanation of selections by including labels as 4th option

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7719,14 +7719,14 @@
         }
       },
       "history": {
-        "start_search": "Start by selecting an area, device or entity above",
+        "start_search": "Select areas, devices, entities or labels above",
         "add_all": "Add all entities",
         "remove_all": "Remove all selections",
         "download_data": "Download data",
         "download_data_error": "Unable to download data",
         "add_card": "Add current view as card",
         "add_card_error": "Unable to add card",
-        "error_no_data": "You need to select data first."
+        "error_no_data": "You need to select some data sources first."
       }
     },
     "tips": {


### PR DESCRIPTION
When you open the History page you are greeted with this explanation:

![image](https://github.com/user-attachments/assets/24acdceb-95f7-46fc-aef6-1112a31d4999)

The use of "Start by …" shows that this information is targeted at beginners to guide them through this page. But it fails to point to the use of labels and the most interesting option to select any combination from the four groups.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR fixes this by rewording:

    Select areas, devices, entities or labels above

This includes labels which are most useful in History as they allow you to select a long list of  similar entities with just a single click. For example any kind of sensors of identical type like occupancy, or all interior lights etc.

It also makes it inherently clear that the really cool feature here is to select multiple entities at once to see them side-by-side or in a single graph.

_For languages with three genders like German this has the additional benefit that using plural solves the issue that it's "der Bereich", "die Entität", "das Gerät" and "das Label" those all become "die Bereiche, Entitäten, Geräte, Labels" in plural. ;-)_

To match that the error message for 'Add current view as card' is also adapted as the current "You need to select data first." is no correct sentence.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22828 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
