### PR TITLE
Display an error if saving new automation times out

### DIFF
--- a/src/common/util/promise-timeout.ts
+++ b/src/common/util/promise-timeout.ts
@@ -1,7 +1,25 @@
+class TimeoutError extends Error {
+  public timeout: number;
+
+  constructor(timeout: number, ...params) {
+    super(...params);
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, TimeoutError);
+    }
+
+    this.name = "TimeoutError";
+    // Custom debugging information
+    this.timeout = timeout;
+    this.message = `Timed out in ${timeout} ms.`;
+  }
+}
+
 export const promiseTimeout = (ms: number, promise: Promise<any> | any) => {
   const timeout = new Promise((_resolve, reject) => {
     setTimeout(() => {
-      reject(`Timed out in ${ms} ms.`);
+      reject(new TimeoutError(ms));
     }, ms);
   });
 

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -143,8 +143,6 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
 
   @state() private _saving = false;
 
-  @state() private _saveFailed = false;
-
   @state()
   @consume({ context: fullEntitiesContext, subscribe: true })
   _entityRegistry!: EntityRegistryEntry[];
@@ -310,13 +308,12 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
 
           <ha-list-item
             .disabled=${this._blueprintConfig ||
-            this._saveFailed ||
             (!this._readOnly && !this.automationId)}
             graphic="icon"
             @click=${this._duplicate}
           >
             ${this.hass.localize(
-              this._readOnly && !this._saveFailed
+              this._readOnly
                 ? "ui.panel.config.automation.editor.migrate"
                 : "ui.panel.config.automation.editor.duplicate"
             )}
@@ -427,7 +424,7 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                   >
                 </div>
               </ha-alert>`
-            : this._readOnly && !this._saveFailed
+            : this._readOnly
               ? html`<ha-alert alert-type="warning" dismissable
                   >${this.hass.localize(
                     "ui.panel.config.automation.editor.read_only"
@@ -500,9 +497,7 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
           class=${classMap({
             dirty: !this._readOnly && this._dirty,
           })}
-          .label=${this._saving
-            ? this.hass.localize("ui.panel.config.automation.editor.saving")
-            : this.hass.localize("ui.panel.config.automation.editor.save")}
+          .label=${this.hass.localize("ui.panel.config.automation.editor.save")}
           .disabled=${this._saving}
           extended
           @click=${this._saveAutomation}
@@ -955,9 +950,6 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
             entityId = automation.entity_id;
           } catch (e) {
             if (e instanceof Error && e.name === "TimeoutError") {
-              this._readOnly = true;
-              this._saveFailed = true;
-              this._dirty = false;
               showAlertDialog(this, {
                 title: this.hass.localize(
                   "ui.panel.config.automation.editor.new_automation_setup_failed_title",
@@ -977,9 +969,9 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                 ),
                 warning: true,
               });
-              return;
+            } else {
+              throw e;
             }
-            throw e;
           }
         }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3021,6 +3021,7 @@
             "load_error_not_deletable": "Only automations in automations.yaml can be deleted.",
             "load_error_unknown": "Error loading automation ({err_no}).",
             "save": "Save",
+            "saving": "Saving",
             "unsaved_confirm_title": "Leave editor?",
             "unsaved_confirm_text": "Unsaved changes will be lost.",
             "alias": "Name",
@@ -3064,6 +3065,10 @@
             "unknown_entity": "unknown entity",
             "edit_unknown_device": "Editor not available for unknown device",
             "switch_ui_yaml_error": "There are currently YAML errors in the automation, and it cannot be parsed. Switching to UI mode may cause pending changes to be lost. Press cancel to correct any errors before proceeding to prevent loss of pending changes, or continue if you are sure.",
+            "type_automation": "automation",
+            "type_script": "script",
+            "new_automation_setup_failed_title": "New {type} setup failed",
+            "new_automation_setup_failed_text": "Your new {type} has saved, but waiting for it to setup has timed out. This could be due to errors parsing your configuration.yaml, please check the configuration in developer tools. Your {type} will not be visible or editable until this is corrected, and automations are reloaded.",
             "triggers": {
               "name": "Triggers",
               "header": "When",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3021,7 +3021,6 @@
             "load_error_not_deletable": "Only automations in automations.yaml can be deleted.",
             "load_error_unknown": "Error loading automation ({err_no}).",
             "save": "Save",
-            "saving": "Saving",
             "unsaved_confirm_title": "Leave editor?",
             "unsaved_confirm_text": "Unsaved changes will be lost.",
             "alias": "Name",
@@ -3068,7 +3067,7 @@
             "type_automation": "automation",
             "type_script": "script",
             "new_automation_setup_failed_title": "New {type} setup failed",
-            "new_automation_setup_failed_text": "Your new {type} has saved, but waiting for it to setup has timed out. This could be due to errors parsing your configuration.yaml, please check the configuration in developer tools. Your {type} will not be visible or editable until this is corrected, and automations are reloaded.",
+            "new_automation_setup_failed_text": "Your new {type} has saved, but waiting for it to setup has timed out. This could be due to errors parsing your configuration.yaml, please check the configuration in developer tools. Your {type} will not be visible until this is corrected, and automations are reloaded. Changes to area, category, or labels were not saved and must be reapplied.",
             "triggers": {
               "name": "Triggers",
               "header": "When",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
If user tries to create a new automation in the visual editor when there is an unrelated error in the configuration.yaml file, when you try to save that automation the editor will appear to just break. 

After clicking `Save` the button will become disabled (grey color), you cannot make any further edits, you cannot leave the automation without going through the "lose your unsaved changes" dialog, and your new automation will appear to have vanished (its not in the automation list). 

The automation is actually successfully saved, but it never appears in the entity registry due to configuration parsing error, so our save flow never actually completes.

This PR adds a warning dialog if a user gets in this situation, otherwise it is very confusing what is happening.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
