### PR TITLE
Changes to the valueText should also rescale ha-gauge text

### DIFF
--- a/src/components/ha-gauge.ts
+++ b/src/components/ha-gauge.ts
@@ -62,6 +62,7 @@ export class HaGauge extends LitElement {
     if (
       !this._updated ||
       (!changedProperties.has("value") &&
+        !changedProperties.has("valueText") &&
         !changedProperties.has("label") &&
         !changedProperties.has("_segment_label"))
     ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When clicking through my energy dashboard, I sometimes noticed that the grid neutrality gauge didn't render correctly:

![image](https://github.com/user-attachments/assets/db6ff13d-a6e4-499e-ab8b-d3503c069c12)

This happens, because `ha-gauge::_rescale_svg()` is only being called on a value or label update:

https://github.com/home-assistant/frontend/blob/f724d8e7a9df8dc1d5c67a6e1eb13abf09b30296/src/components/ha-gauge.ts#L60-L73

This works for _almost_ all cases, however with the `hui-energy-grid-neutrality-gauge-card`, it breaks, because `value` and `valueText` are independent from each other.

This bug **only** occurs, when there are multiple days with the same grid neutrality ratio but kWh usage differing by digit count.
Otherwise, the change of the ratio also triggers the `_rescale_svg()`

According to the github code search, the grid neutrality gauge card is currently the only gauge where that can happen:
https://github.com/search?q=repo%3Ahome-assistant%2Ffrontend%20.valueText&type=code

These two factors are probably why it hasn't been discovered so far.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Default energy dashboard

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
