### PR TITLE
Match UI with core and don't allow restore config without db and vice …

### DIFF
--- a/src/panels/config/backup/components/ha-backup-data-picker.ts
+++ b/src/panels/config/backup/components/ha-backup-data-picker.ts
@@ -77,15 +77,9 @@ export class HaBackupDataPicker extends LitElement {
 
       if (data.homeassistant_included) {
         items.push({
-          label: "Settings",
+          label: `Settings${data.database_included ? " and history" : ""}`,
           id: "config",
           version: data.homeassistant_version,
-        });
-      }
-      if (data.database_included) {
-        items.push({
-          label: "History",
-          id: "database",
         });
       }
       items.push(
@@ -132,9 +126,6 @@ export class HaBackupDataPicker extends LitElement {
     if (value.homeassistant_included) {
       homeassistant.push("config");
     }
-    if (value.database_included) {
-      homeassistant.push("database");
-    }
 
     const folders = value.folders;
     homeassistant.push(...folders);
@@ -151,7 +142,9 @@ export class HaBackupDataPicker extends LitElement {
     (selectedItems: SelectedItems, data: BackupData): BackupData => ({
       homeassistant_version: data.homeassistant_version,
       homeassistant_included: selectedItems.homeassistant.includes("config"),
-      database_included: selectedItems.homeassistant.includes("database"),
+      database_included:
+        data.database_included &&
+        selectedItems.homeassistant.includes("config"),
       addons: data.addons.filter((addon) =>
         selectedItems.addons.includes(addon.slug)
       ),


### PR DESCRIPTION
…versa


## Proposed change

Core doesn't allow to restore the DB without config or config without DB, so we should not offer the options in the UI.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
