### PR TITLE
Fix restoring backup during onboarding

### DIFF
--- a/hassio/src/dialogs/backup/dialog-hassio-backup.ts
+++ b/hassio/src/dialogs/backup/dialog-hassio-backup.ts
@@ -179,8 +179,8 @@ class HassioBackupDialog
   }
 
   private async _restoreClicked() {
-    this._restoringBackup = true;
     const backupDetails = this._backupContent.backupDetails();
+    this._restoringBackup = true;
 
     const supervisor = this._dialogParams?.supervisor;
     if (supervisor !== undefined && supervisor.info.state !== "running") {
@@ -196,12 +196,12 @@ class HassioBackupDialog
     if (
       !(await showConfirmationDialog(this, {
         title: this._localize(
-          this._backupContent.backupType === "full"
+          this._backup!.type === "full"
             ? "confirm_restore_full_backup_title"
             : "confirm_restore_partial_backup_title"
         ),
         text: this._localize(
-          this._backupContent.backupType === "full"
+          this._backup!.type === "full"
             ? "confirm_restore_full_backup_text"
             : "confirm_restore_partial_backup_text"
         ),
@@ -216,9 +216,9 @@ class HassioBackupDialog
     try {
       await restoreBackup(
         this.hass,
-        this._backupContent.backupType,
+        this._backup!.type,
         this._backup!.slug,
-        backupDetails,
+        { ...backupDetails, background: this._dialogParams?.onboarding },
         !!this.hass && atLeastVersion(this.hass.config.version, 2021, 9)
       );
 

--- a/src/data/hassio/backup.ts
+++ b/src/data/hassio/backup.ts
@@ -46,6 +46,7 @@ export interface HassioFullBackupCreateParams {
   name: string;
   password?: string;
   confirm_password?: string;
+  background?: boolean;
 }
 export interface HassioPartialBackupCreateParams
   extends HassioFullBackupCreateParams {


### PR DESCRIPTION



## Proposed change

- `this._backupContent` was used during restoring, but was removed from the DOM because `_restoringBackup` was set to true.
- Do restore in background during onboarding


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
