### PR TITLE
Option to hide create box on todo card

### DIFF
--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -195,11 +195,10 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
           "has-header": "title" in this._config,
         })}
       >
-        <div class="addRow">
-          ${this._todoListSupportsFeature(
-            TodoListEntityFeature.CREATE_TODO_ITEM
-          )
-            ? html`
+        ${!this._config.hide_create &&
+        this._todoListSupportsFeature(TodoListEntityFeature.CREATE_TODO_ITEM)
+          ? html`
+              <div class="addRow">
                 <ha-textfield
                   class="addBox"
                   .placeholder=${this.hass!.localize(
@@ -218,9 +217,9 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                   @click=${this._addItem}
                 >
                 </ha-icon-button>
-              `
-            : nothing}
-        </div>
+              </div>
+            `
+          : nothing}
         <ha-sortable
           handle-selector="ha-svg-icon"
           draggable-selector=".draggable"

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -478,6 +478,7 @@ export interface TodoListCardConfig extends LovelaceCardConfig {
   theme?: string;
   entity?: string;
   hide_completed?: boolean;
+  hide_create?: boolean;
 }
 
 export interface StackCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-todo-list-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-todo-list-editor.ts
@@ -20,6 +20,7 @@ const cardConfigStruct = assign(
     theme: optional(string()),
     entity: optional(string()),
     hide_completed: optional(boolean()),
+    hide_create: optional(boolean()),
   })
 );
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Option (`hide_create: true`) to hide the create box at the top of todo cards. In some views it's not always needed when you just want a display.  

Also move the addrow div inside the conditional, as the extra padding is somewhat excessive when the box is missing (either because of this feature or if its not supported by the entity). (Probably still too much even after this change, but that's a topic for another day)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/todo-list-card-without-add-item/638585

- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
