### PR TITLE
Improve automation save dialog when leaving editor dirty

### DIFF
--- a/src/panels/config/automation/automation-save-dialog/show-dialog-automation-save.ts
+++ b/src/panels/config/automation/automation-save-dialog/show-dialog-automation-save.ts
@@ -3,13 +3,18 @@ import type { AutomationConfig } from "../../../../data/automation";
 import type { ScriptConfig } from "../../../../data/script";
 import type { EntityRegistryEntry } from "../../../../data/entity_registry";
 
-export const loadAutomationRenameDialog = () =>
-  import("./dialog-automation-rename");
+export const loadAutomationSaveDialog = () =>
+  import("./dialog-automation-save");
 
 interface BaseRenameDialogParams {
   entityRegistryUpdate?: EntityRegistryUpdate;
   entityRegistryEntry?: EntityRegistryEntry;
   onClose: () => void;
+  onDiscard?: () => void;
+  saveText?: string;
+  description?: string;
+  title?: string;
+  hideInputs?: boolean;
 }
 
 export interface EntityRegistryUpdate {
@@ -18,31 +23,35 @@ export interface EntityRegistryUpdate {
   category: string;
 }
 
-export interface AutomationRenameDialogParams extends BaseRenameDialogParams {
+export interface AutomationSaveDialogParams extends BaseRenameDialogParams {
   config: AutomationConfig;
   domain: "automation";
   updateConfig: (
     config: AutomationConfig,
     entityRegistryUpdate: EntityRegistryUpdate
-  ) => void;
+  ) => Promise<void>;
 }
 
-export interface ScriptRenameDialogParams extends BaseRenameDialogParams {
+export interface ScriptSaveDialogParams extends BaseRenameDialogParams {
   config: ScriptConfig;
   domain: "script";
   updateConfig: (
     config: ScriptConfig,
     entityRegistryUpdate: EntityRegistryUpdate
-  ) => void;
+  ) => Promise<void>;
 }
 
-export const showAutomationRenameDialog = (
+export type SaveDialogParams =
+  | AutomationSaveDialogParams
+  | ScriptSaveDialogParams;
+
+export const showAutomationSaveDialog = (
   element: HTMLElement,
-  dialogParams: AutomationRenameDialogParams | ScriptRenameDialogParams
+  dialogParams: SaveDialogParams
 ): void => {
   fireEvent(element, "show-dialog", {
-    dialogTag: "ha-dialog-automation-rename",
-    dialogImport: loadAutomationRenameDialog,
+    dialogTag: "ha-dialog-automation-save",
+    dialogImport: loadAutomationSaveDialog,
     dialogParams,
   });
 };

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -760,7 +760,7 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
           const id = this.automationId || String(Date.now());
           try {
             await this._saveAutomation(id);
-          } catch (err: any) {
+          } catch (_err: any) {
             this.requestUpdate();
             resolve(false);
             return;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -62,8 +62,8 @@ import { haStyle } from "../../../resources/styles";
 import type { Entries, HomeAssistant, Route } from "../../../types";
 import { showToast } from "../../../util/toast";
 import { showAutomationModeDialog } from "../automation/automation-mode-dialog/show-dialog-automation-mode";
-import type { EntityRegistryUpdate } from "../automation/automation-rename-dialog/show-dialog-automation-rename";
-import { showAutomationRenameDialog } from "../automation/automation-rename-dialog/show-dialog-automation-rename";
+import type { EntityRegistryUpdate } from "../automation/automation-save-dialog/show-dialog-automation-save";
+import { showAutomationSaveDialog } from "../automation/automation-save-dialog/show-dialog-automation-save";
 import "./blueprint-script-editor";
 import "./manual-script-editor";
 import type { HaManualScriptEditor } from "./manual-script-editor";
@@ -843,10 +843,10 @@ export class HaScriptEditor extends SubscribeMixin(
 
   private async _promptScriptAlias(): Promise<boolean> {
     return new Promise((resolve) => {
-      showAutomationRenameDialog(this, {
+      showAutomationSaveDialog(this, {
         config: this._config!,
         domain: "script",
-        updateConfig: (config, entityRegistryUpdate) => {
+        updateConfig: async (config, entityRegistryUpdate) => {
           this._config = config;
           this._entityRegistryUpdate = entityRegistryUpdate;
           this._dirty = true;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -369,7 +369,8 @@
       "copied_clipboard": "Copied to clipboard",
       "name": "Name",
       "optional": "optional",
-      "default": "Default"
+      "default": "Default",
+      "dont_save": "Don't save"
     },
     "components": {
       "selectors": {
@@ -3429,6 +3430,12 @@
               "label": "Description",
               "placeholder": "Optional description",
               "add": "Add description"
+            },
+            "leave": {
+              "unsaved_new_title": "Save new automation?",
+              "unsaved_new_text": "You can save your changes, or delete this automation. You can't undo this action.",
+              "unsaved_confirm_title": "Save changes?",
+              "unsaved_confirm_text": "You have made some changes in this automation. You can save these changes, or discard them and leave. You can't undo this action."
             },
             "icon": "Icon",
             "blueprint": {


### PR DESCRIPTION
## Proposed change
This PR improves the dialog for saving automations, to be used if the user wants to leave the editor in an dirty state. Either when creating a new automation or when editing an existing one.

I also renamed the dialog to `save` instead of `rename`, as it is now more about saving and not renaming.

Edit: Worked closely with @matthiasdebaat on Discord again on that. The design is based on his mockup.

| <img width="610" alt="image" src="https://github.com/user-attachments/assets/4b450dc9-c234-4890-a93a-7880c948f2a7" /> | <img width="623" alt="image" src="https://github.com/user-attachments/assets/618a3028-b992-406a-b5c1-73ee6c35e4e3" /> | 
| :-: | :-: |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
