### PR TITLE
Reduce min_columns of Tile Card to 3 to improve look

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -111,14 +111,13 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
 
   public getGridOptions(): LovelaceGridOptions {
     const columns = 6;
-    let min_columns = 6;
+    const min_columns = 3;
     let rows = 1;
     if (this._config?.features?.length) {
       rows += this._config.features.length;
     }
     if (this._config?.vertical) {
       rows++;
-      min_columns = 3;
     }
     return {
       columns,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The tile card has a minimum column width of 6. For some entities this leaves a lot of empty space on the tile card, which looks odd. A default width of 6 is sensible, but the user should have the freedom to make it less wide if desired. In the screenshot below, the left Coffee input_datetime has a default width of 6, the right Coffee input_datetime a width 4, and the bottom Coffee input_datetime a width 3.

![image](https://github.com/user-attachments/assets/237415de-8993-4228-bfba-6ddcef4b944e)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
entity: input_datetime.coffee_machine_start_time
name: Coffee
grid_options:
  columns: 4
  rows: 1
icon: mdi:coffee-maker
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
