### PR TITLE
Show yaml parsing errors in hui-element-editor

### DIFF
--- a/src/panels/lovelace/editor/hui-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-element-editor.ts
@@ -4,6 +4,7 @@ import { property, query, state } from "lit/decorators";
 import { cache } from "lit/directives/cache";
 import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { debounce } from "../../../common/util/debounce";
 import { handleStructError } from "../../../common/structs/handle-errors";
 import { deepEqual } from "../../../common/util/deep-equal";
 import "../../../components/ha-alert";
@@ -66,6 +67,11 @@ export abstract class HuiElementEditor<
 
   // Error: Configuration broken - do not save
   @state() private _errors?: string[];
+
+  // Error from unparseable YAML, but don't show it immediately to prevent showing immediately on every keystroke
+  @state() private _pendingYamlError?: string;
+
+  @state() private _yamlError = false;
 
   // Warning: GUI editor can't handle configuration - ok to save
   @state() private _warnings?: string[];
@@ -237,6 +243,7 @@ export abstract class HuiElementEditor<
                   autofocus
                   .hass=${this.hass}
                   @value-changed=${this._handleYAMLChanged}
+                  @blur=${this._onBlurYaml}
                   @keydown=${this._ignoreKeydown}
                   dir="ltr"
                 ></ha-yaml-editor>
@@ -327,6 +334,34 @@ export abstract class HuiElementEditor<
     if (ev.detail.isValid) {
       this._config = config;
       this._errors = undefined;
+      this._pendingYamlError = undefined;
+      this._yamlError = false;
+      this._debounceYamlError.cancel();
+      this._setConfig();
+    } else if (this._yamlError) {
+      // If we're already showing a yaml error, don't bother to debounce, just update immediately.
+      this._errors = [ev.detail.errorMsg];
+    } else {
+      this._pendingYamlError = ev.detail.errorMsg;
+      this._debounceYamlError();
+    }
+  }
+
+  private _debounceYamlError = debounce(() => {
+    if (this._pendingYamlError) {
+      this._yamlError = true;
+      this._errors = [this._pendingYamlError];
+      this._pendingYamlError = undefined;
+      this._setConfig();
+    }
+  }, 2000);
+
+  private _onBlurYaml() {
+    this._debounceYamlError.cancel();
+    if (this._pendingYamlError) {
+      this._yamlError = true;
+      this._errors = [this._pendingYamlError];
+      this._pendingYamlError = undefined;
       this._setConfig();
     }
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
If there are yaml errors in a card editor, show those errors in the window. 

Currently they are not shown, and if we click "Save", the window closes and any pending changes are lost. The only indication of an error is a red line on the side of the codemirror box, which is not always obvious to every user what it means. 

This change shows yaml errors in the window, and disables the save button when there are yaml errors.

I have also elected to do a bit of debouncing on this detection, because if we just show the error immediately, it will show an error immediately every time a user types a keystroke on a new line, which I think is too aggressive. 

So this only shows the error either after user pauses typing for 2 seconds, or when the codemirror box is blurred. 

![image](https://github.com/user-attachments/assets/b23cadb0-6136-41a0-babe-274c75dd705b)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
