### PR TITLE
Fix navigation from stacked dialogs with the same name

### DIFF
--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -174,7 +174,9 @@ export const closeLastDialog = async () => {
 export const closeAllDialogs = async () => {
   for (let i = OPEN_DIALOG_STACK.length - 1; i >= 0; i--) {
     // eslint-disable-next-line no-await-in-loop
-    const closed = await closeDialog(OPEN_DIALOG_STACK[i].dialogTag);
+    const closed =
+      !OPEN_DIALOG_STACK[i] ||
+      (await closeDialog(OPEN_DIALOG_STACK[i].dialogTag));
     if (!closed) {
       return false;
     }

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -173,9 +173,9 @@ export const closeLastDialog = async () => {
 
 export const closeAllDialogs = async () => {
   for (let i = OPEN_DIALOG_STACK.length - 1; i >= 0; i--) {
-    // eslint-disable-next-line no-await-in-loop
     const closed =
       !OPEN_DIALOG_STACK[i] ||
+      // eslint-disable-next-line no-await-in-loop
       (await closeDialog(OPEN_DIALOG_STACK[i].dialogTag));
     if (!closed) {
       return false;

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -104,6 +104,12 @@ export const showDialog = async (
         addHistory
       );
     }
+    const dialogIndex = OPEN_DIALOG_STACK.findIndex(
+      (state) => state.dialogTag === dialogTag
+    );
+    if (dialogIndex !== -1) {
+      OPEN_DIALOG_STACK.splice(dialogIndex, 1);
+    }
     OPEN_DIALOG_STACK.push({
       element,
       root,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When 2 the same dialog appears twice in the stack, the first `closeDialog` call closes both, so the second one is missing from the stack when the loop gets to it. Not sure the closing behavior should be changed but for the linked bug, checking the state is enough.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#134766
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
