### PR TITLE
Improve weather forecast card layout

### DIFF
--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -474,7 +474,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
           flex-wrap: nowrap;
           justify-content: space-between;
           align-items: center;
-          padding: 0px 16px;
+          padding: 0 16px;
         }
 
         .content + .forecast {
@@ -557,7 +557,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         .forecast {
           display: flex;
           justify-content: space-around;
-          padding: 0px 16px;
+          padding: 0 16px;
         }
 
         .forecast > div {
@@ -566,7 +566,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
         .forecast .icon,
         .forecast .temp {
-          margin: 0px 0;
+          margin: 0;
         }
 
         .forecast .temp {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -134,12 +134,15 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   }
 
   public getCardSize(): number {
-    let cardSize = 0;
+    let cardSize = 1;
     if (this._config?.show_current !== false) {
-      cardSize += 2;
+      cardSize += 1;
     }
     if (this._config?.show_forecast !== false) {
-      cardSize += 3;
+      cardSize += 1;
+    }
+    if (this._config?.forecast_type === "daily") {
+      cardSize += 1;
     }
     return cardSize;
   }
@@ -218,12 +221,19 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       this._forecastEvent,
       this._config?.forecast_type
     );
+
+    let itemsToShow = this._config?.forecast_slots ?? 5;
+    if (this._sizeController.value === "very-very-narrow") {
+      itemsToShow = Math.min(3, itemsToShow);
+    } else if (this._sizeController.value === "very-narrow") {
+      itemsToShow = Math.min(5, itemsToShow);
+    } else if (this._sizeController.value === "narrow") {
+      itemsToShow = Math.min(7, itemsToShow);
+    }
+
     const forecast =
       this._config?.show_forecast !== false && forecastData?.forecast?.length
-        ? forecastData.forecast.slice(
-            0,
-            this._sizeController.value === "very-very-narrow" ? 3 : 5
-          )
+        ? forecastData.forecast.slice(0, itemsToShow)
         : undefined;
     const weather = !forecast || this._config?.show_current !== false;
 
@@ -419,30 +429,24 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   }
 
   public getGridOptions(): LovelaceGridOptions {
-    if (
-      this._config?.show_current !== false &&
-      this._config?.show_forecast !== false
-    ) {
-      return {
-        columns: 12,
-        rows: 4,
-        min_columns: 6,
-        min_rows: 4,
-      };
+    let rows = 1;
+    let min_rows = 1;
+    if (this._config?.show_current !== false) {
+      rows += 1;
+      min_rows += 1;
     }
     if (this._config?.show_forecast !== false) {
-      return {
-        columns: 12,
-        rows: 3,
-        min_columns: 6,
-        min_rows: 3,
-      };
+      rows += 1;
+      min_rows += 1;
+    }
+    if (this._config?.forecast_type === "daily") {
+      rows += 1;
     }
     return {
       columns: 12,
-      rows: 2,
+      rows: rows,
       min_columns: 6,
-      min_rows: 2,
+      min_rows: min_rows,
     };
   }
 
@@ -462,7 +466,6 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
           display: flex;
           flex-direction: column;
           justify-content: center;
-          padding: 16px;
           box-sizing: border-box;
         }
 
@@ -471,6 +474,11 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
           flex-wrap: nowrap;
           justify-content: space-between;
           align-items: center;
+          padding: 0px 16px;
+        }
+
+        .content + .forecast {
+          padding-top: 8px;
         }
 
         .icon-image {
@@ -549,7 +557,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         .forecast {
           display: flex;
           justify-content: space-around;
-          padding-top: 16px;
+          padding: 0px 16px;
         }
 
         .forecast > div {
@@ -558,7 +566,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
         .forecast .icon,
         .forecast .temp {
-          margin: 4px 0;
+          margin: 0px 0;
         }
 
         .forecast .temp {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -507,6 +507,7 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
   show_current?: boolean;
   show_forecast?: boolean;
   forecast_type?: ForecastType;
+  forecast_slots?: number;
   secondary_info_attribute?: keyof TranslationDict["ui"]["card"]["weather"]["attributes"];
   theme?: string;
   tap_action?: ActionConfig;

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -1,7 +1,15 @@
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import { assert, assign, boolean, object, optional, string } from "superstruct";
+import {
+  assert,
+  assign,
+  boolean,
+  object,
+  optional,
+  string,
+  number,
+} from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
@@ -25,6 +33,7 @@ const cardConfigStruct = assign(
     show_current: optional(boolean()),
     show_forecast: optional(boolean()),
     forecast_type: optional(string()),
+    forecast_slots: optional(number()),
     secondary_info_attribute: optional(string()),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
@@ -225,6 +234,11 @@ export class HuiWeatherForecastCardEditor
                   },
                 },
               },
+              {
+                name: "forecast_slots",
+                selector: { number: { min: 1, max: 12 } },
+                default: 5,
+              },
             ] as const)
           : []),
       ] as const
@@ -303,6 +317,10 @@ export class HuiWeatherForecastCardEditor
       case "forecast_type":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.card.weather-forecast.forecast_type"
+        );
+      case "forecast_slots":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.card.weather-forecast.forecast_slots"
         );
       case "forecast":
         return this.hass!.localize(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7120,6 +7120,7 @@
               "show_only_current": "Show only current Weather",
               "show_only_forecast": "Show only forecast",
               "forecast_type": "Select forecast type",
+              "forecast_slots": "How many forecast elements to show",
               "no_type": "No type",
               "daily": "Daily",
               "hourly": "Hourly",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7120,7 +7120,7 @@
               "show_only_current": "Show only current Weather",
               "show_only_forecast": "Show only forecast",
               "forecast_type": "Select forecast type",
-              "forecast_slots": "How many forecast elements to show",
+              "forecast_slots": "Maximum number of forecast elements to show",
               "no_type": "No type",
               "daily": "Daily",
               "hourly": "Hourly",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The weather forecast card is rather space in-efficient and includes a lot of empty space. Here is a screenshot of the weather card, showing 1. Current Weather (2 rows), 2. Hourly forecast (3 rows), 3. Daily forefast (3 rows), 4. Current Weather and Daily Forecast (4 rows), and 5. Current weather and Hourly forecast (4 rows).  In particular around 2. and 5. there is a lot of empty vertical space.

![Screenshot 2025-01-11 213039](https://github.com/user-attachments/assets/79b803d3-686b-4150-8a7d-ba5dccebcb84)

I think it looks now a little more similar to the tile cards, although the size could probably be compressed further still.

This pull request adjusts the styling of the cards to enable them to fit them into slighty fewer rows.

![Screenshot 2025-01-11 234200](https://github.com/user-attachments/assets/6184b826-b334-46ad-b3d9-53dd8522e12a)

I have also added a configuration option to adjust the number of forecast slots to show. The default is still 5 to not change existing installations (but in my opinion 7 looks better).

![Screenshot 2025-01-12 171206](https://github.com/user-attachments/assets/ead32f07-8c4d-432e-b673-8573bfcb641e)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
views:
  - title: Home
    sections:
      - type: grid
        cards:
          - type: heading
            heading: Weather
            heading_style: title
          - type: tile
            entity: sensor.sun_next_dawn
          - type: entities
            entities:
              - entity: sensor.sun_next_dusk
          - type: weather-forecast
            entity: weather.forecast_home
            show_forecast: false
            forecast_type: daily
            grid_options:
              columns: 12
              rows: 2
          - show_current: false
            show_forecast: true
            type: weather-forecast
            entity: weather.forecast_home
            forecast_type: hourly
            grid_options:
              columns: 12
              rows: 2
            forecast_slots: 5
          - show_current: false
            show_forecast: true
            type: weather-forecast
            entity: weather.forecast_home
            forecast_type: daily
            forecast_slots: 7
          - show_current: true
            show_forecast: true
            type: weather-forecast
            entity: weather.forecast_home
            forecast_type: hourly
            forecast_slots: 5
          - type: weather-forecast
            entity: weather.forecast_home
            forecast_type: daily
            grid_options:
              columns: 12
              rows: 4
          - show_current: false
            show_forecast: true
            type: weather-forecast
            entity: weather.forecast_home
            forecast_type: hourly
            forecast_slots: 10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I have added a new localization string "ui.panel.lovelace.editor.card.weather-forecast.forecast_slots".

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
