### PR TITLE
Add shortcut hint to assist dialog

### DIFF
--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -191,7 +191,7 @@ export class HaVoiceCommandDialog extends LitElement {
               </div>`}
         ${this._hint
           ? html`<ha-tip .hass=${this.hass}>${this._hint}</ha-tip>`
-          : ""}
+          : nothing}
       </ha-dialog>
     `;
   }

--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -320,7 +320,7 @@ export class HaVoiceCommandDialog extends LitElement {
           min-height: 399px;
         }
         ha-tip {
-          padding-bottom: 14px;
+          padding-bottom: 16px;
         }
       `,
     ];

--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -29,6 +29,7 @@ import { haStyleDialog } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
 import type { VoiceCommandDialogParams } from "./show-ha-voice-command-dialog";
+import "../../components/ha-tip";
 
 @customElement("ha-voice-command-dialog")
 export class HaVoiceCommandDialog extends LitElement {
@@ -51,6 +52,8 @@ export class HaVoiceCommandDialog extends LitElement {
 
   @state() private _errorLoadAssist?: "not_found" | "unknown";
 
+  @state() private _hint?: string;
+
   private _startListening = false;
 
   public async showDialog(
@@ -68,6 +71,7 @@ export class HaVoiceCommandDialog extends LitElement {
 
     this._startListening = params.start_listening;
     this._opened = true;
+    this._hint = params.hint;
   }
 
   public async closeDialog(): Promise<void> {
@@ -185,6 +189,9 @@ export class HaVoiceCommandDialog extends LitElement {
                   size="large"
                 ></ha-circular-progress>
               </div>`}
+        ${this._hint
+          ? html`<ha-tip .hass=${this.hass}>${this._hint}</ha-tip>`
+          : ""}
       </ha-dialog>
     `;
   }
@@ -247,7 +254,7 @@ export class HaVoiceCommandDialog extends LitElement {
       css`
         ha-dialog {
           --mdc-dialog-max-width: 500px;
-          --mdc-dialog-max-height: 500px;
+          --mdc-dialog-max-height: 550px;
           --dialog-content-padding: 0;
         }
         ha-dialog-header a {
@@ -311,6 +318,9 @@ export class HaVoiceCommandDialog extends LitElement {
         ha-assist-chat {
           margin: 0 24px 16px;
           min-height: 399px;
+        }
+        ha-tip {
+          padding-bottom: 14px;
         }
       `,
     ];

--- a/src/dialogs/voice-command-dialog/show-ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/show-ha-voice-command-dialog.ts
@@ -6,6 +6,7 @@ const loadVoiceCommandDialog = () => import("./ha-voice-command-dialog");
 export interface VoiceCommandDialogParams {
   pipeline_id: "last_used" | "preferred" | string;
   start_listening?: boolean;
+  hint?: string;
 }
 
 export const showVoiceCommandDialog = (
@@ -31,6 +32,7 @@ export const showVoiceCommandDialog = (
       pipeline_id: dialogParams.pipeline_id,
       // Don't start listening by default for web
       start_listening: dialogParams.start_listening ?? false,
+      hint: dialogParams.hint,
     },
   });
 };

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -730,7 +730,12 @@ class HUIRoot extends LitElement {
   }
 
   private _showVoiceCommandDialog(): void {
-    showVoiceCommandDialog(this, this.hass, { pipeline_id: "last_used" });
+    showVoiceCommandDialog(this, this.hass, {
+      pipeline_id: "last_used",
+      hint: this.hass.enableShortcuts
+        ? this.hass.localize("ui.tips.key_a_hint")
+        : undefined,
+    });
   }
 
   private _handleEnableEditMode(ev: CustomEvent<RequestSelectedDetail>): void {


### PR DESCRIPTION
## Proposed change
Add a shortcut hint to the assist dialog when it is opened via the topbar.

| Opened via shortcut | Opened via topbar |
| :-: | :-: |
| <img width="422" alt="image" src="https://github.com/user-attachments/assets/d5e9d81e-acb0-44df-9b88-17f8d6118329" /> | <img width="427" alt="image" src="https://github.com/user-attachments/assets/dbfc83c2-d420-4890-aa7a-5fbe4587eca1" /> |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23725
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
