### PR TITLE
Add event listener to show config / options flow

### DIFF
--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import { mainWindow } from "../../common/dom/get_main_window";
 import {
   createConfigFlow,
   deleteConfigFlow,
@@ -11,6 +12,22 @@ import {
   loadDataEntryFlowDialog,
   showFlowDialog,
 } from "./show-dialog-data-entry-flow";
+
+declare global {
+  // for fire event
+  interface HASSDomEvents {
+    "show-config-flow-dialog": {
+      dialogParams?: Omit<DataEntryFlowDialogParams, "flowConfig">;
+    };
+  }
+}
+
+export const addEventListenerConfigFlow = (el: HTMLElement) => {
+  mainWindow.addEventListener("show-options-flow-dialog", (ev) => {
+    const dialogParams = ev.detail.dialogParams;
+    showConfigFlowDialog(el, dialogParams);
+  });
+};
 
 export const loadConfigFlowDialog = loadDataEntryFlowDialog;
 

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import { mainWindow } from "../../common/dom/get_main_window";
 import type { ConfigEntry } from "../../data/config_entries";
 import { domainToName } from "../../data/integration";
 import {
@@ -12,6 +13,24 @@ import {
   loadDataEntryFlowDialog,
   showFlowDialog,
 } from "./show-dialog-data-entry-flow";
+
+declare global {
+  // for fire event
+  interface HASSDomEvents {
+    "show-options-flow-dialog": {
+      configEntry: ConfigEntry;
+      dialogParams?: Omit<DataEntryFlowDialogParams, "flowConfig">;
+    };
+  }
+}
+
+export const addEventListenerOptionsFlow = (el: HTMLElement) => {
+  mainWindow.addEventListener("show-options-flow-dialog", (ev) => {
+    const configEntry = ev.detail.configEntry;
+    const dialogParams = ev.detail.dialogParams;
+    showOptionsFlowDialog(el, configEntry, dialogParams);
+  });
+};
 
 export const loadOptionsFlowDialog = loadDataEntryFlowDialog;
 

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -7,6 +7,8 @@ import { getStorageDefaultPanelUrlPath } from "../data/panel";
 import type { WindowWithPreloads } from "../data/preloads";
 import type { RecorderInfo } from "../data/recorder";
 import { getRecorderInfo } from "../data/recorder";
+import { addEventListenerConfigFlow } from "../dialogs/config-flow/show-dialog-config-flow";
+import { addEventListenerOptionsFlow } from "../dialogs/config-flow/show-dialog-options-flow";
 import "../resources/custom-card-support";
 import { HassElement } from "../state/hass-element";
 import QuickBarMixin from "../state/quick-bar-mixin";
@@ -138,6 +140,10 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
         navigate(href);
       }
     });
+
+    // Handle data entry flow requessts
+    addEventListenerConfigFlow(this);
+    addEventListenerOptionsFlow(this);
 
     // Render launch screen info box (loading data / error message)
     // if Home Assistant is not loaded yet.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This adds two event listeners on `mainWindow` for opening a config (reconfigure) or options flow dialog
- `"show-config-flow-dialog"`
- `"show-options-flow-dialog"`

It can be used by integration configuration panels to open a data entry flow for its config entry from an iFrame while running the flow code of current core frontend.

Calling `showOptionsFlowDialog` from an iFrame directly (using a vendored frontend version) currently doesn't work properly due to some obscure JS-issue I don't fully understand tbh.
TLDR: `instanceof Promise` isn't necessarily `true` for every Promise so the flow code breaks
Full story discord thread: https://discord.com/channels/330944238910963714/1327008141061132318
It would also possibly introduce compatibility issues when the flow code of the vendored frontend version doesn't match HA cores expected version.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
