### PR TITLE
Fix-ha-form-float-validate

### DIFF
--- a/src/components/ha-form/ha-form-float.ts
+++ b/src/components/ha-form/ha-form-float.ts
@@ -36,7 +36,7 @@ export class HaFormFloat extends LitElement implements HaFormElement {
   protected render(): TemplateResult {
     return html`
       <ha-textfield
-        type="numeric"
+        type="number"
         inputMode="decimal"
         .label=${this.label}
         .helper=${this.helper}
@@ -84,11 +84,6 @@ export class HaFormFloat extends LitElement implements HaFormElement {
 
     // Detect anything changed
     if (this.data === value) {
-      // parseFloat will drop invalid text at the end, in that case update textfield
-      const newRawValue = value === undefined ? "" : String(value);
-      if (source.value !== newRawValue) {
-        source.value = newRawValue;
-      }
       return;
     }
 

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -91,7 +91,6 @@ import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import { showToast } from "../../../util/toast";
 import { showDeviceRegistryDetailDialog } from "../devices/device-registry-detail/show-dialog-device-registry-detail";
-import { autoCaseNoun } from "../../../common/translations/auto_case_noun";
 
 const OVERRIDE_DEVICE_CLASSES = {
   cover: [
@@ -1136,10 +1135,10 @@ export class EntityRegistrySettingsEditor extends LitElement {
           text: this.hass!.localize(
             "ui.dialogs.entity_registry.editor.switch_as_x_confirm",
             {
-              domain: autoCaseNoun(
-                domainToName(this.hass.localize, this._switchAsDomain),
-                this.hass.locale.language
-              ),
+              domain: domainToName(
+                this.hass.localize,
+                this._switchAsDomain
+              ).toLowerCase(),
             }
           ),
         })
@@ -1178,23 +1177,23 @@ export class EntityRegistrySettingsEditor extends LitElement {
               ? this.hass!.localize(
                   "ui.dialogs.entity_registry.editor.switch_as_x_remove_confirm",
                   {
-                    domain: autoCaseNoun(
-                      domainToName(this.hass.localize, domain),
-                      this.hass.locale.language
-                    ),
+                    domain: domainToName(
+                      this.hass.localize,
+                      domain
+                    ).toLowerCase(),
                   }
                 )
               : this.hass!.localize(
                   "ui.dialogs.entity_registry.editor.switch_as_x_change_confirm",
                   {
-                    domain_1: autoCaseNoun(
-                      domainToName(this.hass.localize, domain),
-                      this.hass.locale.language
-                    ),
-                    domain_2: autoCaseNoun(
-                      domainToName(this.hass.localize, this._switchAsDomain),
-                      this.hass.locale.language
-                    ),
+                    domain_1: domainToName(
+                      this.hass.localize,
+                      domain
+                    ).toLowerCase(),
+                    domain_2: domainToName(
+                      this.hass.localize,
+                      this._switchAsDomain
+                    ).toLowerCase(),
                   }
                 ),
         })

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -91,6 +91,7 @@ import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import { showToast } from "../../../util/toast";
 import { showDeviceRegistryDetailDialog } from "../devices/device-registry-detail/show-dialog-device-registry-detail";
+import { autoCaseNoun } from "../../../common/translations/auto_case_noun";
 
 const OVERRIDE_DEVICE_CLASSES = {
   cover: [
@@ -1135,10 +1136,10 @@ export class EntityRegistrySettingsEditor extends LitElement {
           text: this.hass!.localize(
             "ui.dialogs.entity_registry.editor.switch_as_x_confirm",
             {
-              domain: domainToName(
-                this.hass.localize,
-                this._switchAsDomain
-              ).toLowerCase(),
+              domain: autoCaseNoun(
+                domainToName(this.hass.localize, this._switchAsDomain),
+                this.hass.locale.language
+              ),
             }
           ),
         })
@@ -1177,23 +1178,23 @@ export class EntityRegistrySettingsEditor extends LitElement {
               ? this.hass!.localize(
                   "ui.dialogs.entity_registry.editor.switch_as_x_remove_confirm",
                   {
-                    domain: domainToName(
-                      this.hass.localize,
-                      domain
-                    ).toLowerCase(),
+                    domain: autoCaseNoun(
+                      domainToName(this.hass.localize, domain),
+                      this.hass.locale.language
+                    ),
                   }
                 )
               : this.hass!.localize(
                   "ui.dialogs.entity_registry.editor.switch_as_x_change_confirm",
                   {
-                    domain_1: domainToName(
-                      this.hass.localize,
-                      domain
-                    ).toLowerCase(),
-                    domain_2: domainToName(
-                      this.hass.localize,
-                      this._switchAsDomain
-                    ).toLowerCase(),
+                    domain_1: autoCaseNoun(
+                      domainToName(this.hass.localize, domain),
+                      this.hass.locale.language
+                    ),
+                    domain_2: autoCaseNoun(
+                      domainToName(this.hass.localize, this._switchAsDomain),
+                      this.hass.locale.language
+                    ),
                   }
                 ),
         })


### PR DESCRIPTION
## Proposed change
- Fix `ha-form-float` validation
  - use native html number type to validate
  - allows trailing 0 behind the comma

Close #22955

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
