### PR TITLE
Prevent race in dialog box

### DIFF
--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -31,7 +31,7 @@ class DialogBox extends LitElement {
   private _closeResolve?: () => void;
 
   public async showDialog(params: DialogBoxParams): Promise<void> {
-    if (this._closeState) {
+    if (this._closePromise) {
       await this._closePromise;
     }
     this._params = params;

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -26,7 +26,14 @@ class DialogBox extends LitElement {
 
   @query("ha-md-dialog") private _dialog?: HaMdDialog;
 
+  private _closePromise?: Promise<void>;
+
+  private _closeResolve?: () => void;
+
   public async showDialog(params: DialogBoxParams): Promise<void> {
+    if (this._closeState) {
+      await this._closePromise;
+    }
     this._params = params;
   }
 
@@ -131,21 +138,24 @@ class DialogBox extends LitElement {
 
   private _dismiss(): void {
     this._closeState = "canceled";
-    this._closeDialog();
     this._cancel();
+    this._closeDialog();
   }
 
   private _confirm(): void {
     this._closeState = "confirmed";
-    this._closeDialog();
     if (this._params!.confirm) {
       this._params!.confirm(this._textField?.value);
     }
+    this._closeDialog();
   }
 
   private _closeDialog() {
     fireEvent(this, "dialog-closed", { dialog: this.localName });
     this._dialog?.close();
+    this._closePromise = new Promise((resolve) => {
+      this._closeResolve = resolve;
+    });
   }
 
   private _dialogClosed() {
@@ -155,6 +165,8 @@ class DialogBox extends LitElement {
     }
     this._closeState = undefined;
     this._params = undefined;
+    this._closeResolve?.();
+    this._closeResolve = undefined;
   }
 
   static styles = css`


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When a dialog would be opened when another one is still closing (before the animation finishes) the new dialog will not open.

This adds a promise that is awaited so we wait for the dialog to be closed before opening it again.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
