### PR TITLE
Use fixed positioning for ha-form-multi_select

### DIFF
--- a/src/components/ha-form/ha-form-multi_select.ts
+++ b/src/components/ha-form/ha-form-multi_select.ts
@@ -79,6 +79,7 @@ export class HaFormMultiSelect extends LitElement implements HaFormElement {
         .disabled=${this.disabled}
         @opening=${this._handleOpen}
         @closing=${this._handleClose}
+        positioning="fixed"
       >
         <ha-textfield
           slot="trigger"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Attempt to fix ha-form-multi_select used in a dialog. Apparently it's been not behaving well since it was updated from MD2 to MD3. 

Changing the positioning to fixed seems to behave more like as would be expected. I cannot imagine every possible usecase of this form element, so I can't test that this works correctly in every case. 

Unsure if using fixed positioning could have any drawbacks. Unsure if I should try to limit the positioning change to some subset of instances (in dialogs only?). It looks fine with this change in time-condition which is the other usecase I know of.

Current (using github integration options flow as example):

![image](https://github.com/user-attachments/assets/60da2af2-9b8f-41f7-b235-a39718140f8e)

With fix:

![image](https://github.com/user-attachments/assets/e84c54c3-d362-4088-9d0a-89ab8af9dd45)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23583
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
