### PR TITLE
Use `destructive` attribute from `ha-button`

### DIFF
--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -1,7 +1,6 @@
 import { mdiAlertOutline } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
-import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-md-dialog";
@@ -117,9 +116,7 @@ class DialogBox extends LitElement {
             @click=${this._confirm}
             ?dialogInitialFocus=${!this._params.prompt &&
             !this._params.destructive}
-            class=${classMap({
-              destructive: this._params.destructive || false,
-            })}
+            ?destructive=${this._params.destructive || false}
           >
             ${this._params.confirmText
               ? this._params.confirmText
@@ -186,9 +183,6 @@ class DialogBox extends LitElement {
     }
     .secondary {
       color: var(--secondary-text-color);
-    }
-    .destructive {
-      --mdc-theme-primary: var(--error-color);
     }
     ha-textfield {
       width: 100%;

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -116,7 +116,7 @@ class DialogBox extends LitElement {
             @click=${this._confirm}
             ?dialogInitialFocus=${!this._params.prompt &&
             !this._params.destructive}
-            ?destructive=${this._params.destructive || false}
+            ?destructive=${this._params.destructive}
           >
             ${this._params.confirmText
               ? this._params.confirmText

--- a/src/panels/calendar/confirm-event-dialog-box.ts
+++ b/src/panels/calendar/confirm-event-dialog-box.ts
@@ -1,4 +1,3 @@
-import "@material/mwc-button/mwc-button";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
@@ -8,6 +7,7 @@ import "../../components/ha-switch";
 import { RecurrenceRange } from "../../data/calendar";
 import type { HomeAssistant } from "../../types";
 import type { ConfirmEventDialogBoxParams } from "./show-confirm-event-dialog-box";
+import "../../components/ha-button";
 
 @customElement("confirm-event-dialog-box")
 class ConfirmEventDialogBox extends LitElement {
@@ -40,26 +40,26 @@ class ConfirmEventDialogBox extends LitElement {
         <div>
           <p>${this._params.text}</p>
         </div>
-        <mwc-button @click=${this._dismiss} slot="secondaryAction">
+        <ha-button @click=${this._dismiss} slot="secondaryAction">
           ${this.hass.localize("ui.dialogs.generic.cancel")}
-        </mwc-button>
-        <mwc-button
+        </ha-button>
+        <ha-button
           slot="primaryAction"
           @click=${this._confirm}
           dialogInitialFocus
-          class="destructive"
+          destructive
         >
           ${this._params.confirmText}
-        </mwc-button>
+        </ha-button>
         ${this._params.confirmFutureText
           ? html`
-              <mwc-button
+              <ha-button
                 @click=${this._confirmFuture}
-                class="destructive"
                 slot="primaryAction"
+                destructive
               >
                 ${this._params.confirmFutureText}
-              </mwc-button>
+              </ha-button>
             `
           : ""}
       </ha-dialog>
@@ -119,9 +119,6 @@ class ConfirmEventDialogBox extends LitElement {
     }
     .secondary {
       color: var(--secondary-text-color);
-    }
-    .destructive {
-      --mdc-theme-primary: var(--error-color);
     }
     ha-dialog {
       /* Place above other dialogs */

--- a/src/panels/config/backup/dialogs/dialog-restore-backup.ts
+++ b/src/panels/config/backup/dialogs/dialog-restore-backup.ts
@@ -222,7 +222,7 @@ class DialogRestoreBackup extends LitElement implements HassDialog {
       <ha-button @click=${this.closeDialog}>
         ${this.hass.localize("ui.common.cancel")}
       </ha-button>
-      <ha-button @click=${this._restoreBackup} class="destructive">
+      <ha-button @click=${this._restoreBackup} destructive>
         ${this.hass.localize(
           "ui.panel.config.backup.dialogs.restore.actions.restore"
         )}
@@ -349,9 +349,6 @@ class DialogRestoreBackup extends LitElement implements HassDialog {
         }
         .content p {
           margin: 0 0 16px;
-        }
-        .destructive {
-          --mdc-theme-primary: var(--error-color);
         }
         .centered {
           display: flex;


### PR DESCRIPTION
# Proposed change
Instead of copying around the `.destructive` class for `ha-button` use the new `destructive` attribute (introduced in https://github.com/home-assistant/frontend/pull/23774).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
