### PR TITLE
Picture glance alignment fix

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -354,6 +354,7 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
       font-size: 16px;
       line-height: 40px;
       color: var(--ha-picture-card-text-color, white);
+      align-self: center;
     }
 
     ha-icon-button {

--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -375,6 +375,7 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      color: var(--ha-picture-card-text-color, white);
     }
     .row {
       display: flex;

--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -323,11 +323,9 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
       height: 100%;
       box-sizing: border-box;
     }
-
     hui-image.clickable {
       cursor: pointer;
     }
-
     .box {
       position: absolute;
       left: 0;
@@ -342,7 +340,6 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
       justify-content: space-between;
       flex-direction: row;
     }
-
     .box .title {
       font-weight: 500;
       margin-left: 8px;
@@ -356,13 +353,11 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
       color: var(--ha-picture-card-text-color, white);
       align-self: center;
     }
-
     ha-icon-button {
       --mdc-icon-button-size: 40px;
       --disabled-text-color: currentColor;
       color: var(--ha-picture-icon-button-color, #a9a9a9);
     }
-
     ha-icon-button.state-on {
       color: var(--ha-picture-icon-button-on-color, white);
     }

--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -353,6 +353,9 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
       color: var(--ha-picture-card-text-color, white);
       align-self: center;
     }
+    ha-state-icon {
+      font-size: 0;
+    }
     ha-icon-button {
       --mdc-icon-button-size: 40px;
       --disabled-text-color: currentColor;

--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -329,12 +329,6 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
     }
 
     .box {
-      /* start paper-font-common-nowrap style */
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      /* end paper-font-common-nowrap style */
-
       position: absolute;
       left: 0;
       right: 0;
@@ -344,9 +338,6 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
         rgba(0, 0, 0, 0.3)
       );
       padding: 4px 8px;
-      font-size: 16px;
-      line-height: 40px;
-      color: var(--ha-picture-card-text-color, white);
       display: flex;
       justify-content: space-between;
       flex-direction: row;
@@ -357,6 +348,12 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
       margin-left: 8px;
       margin-inline-start: 8px;
       margin-inline-end: initial;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      font-size: 16px;
+      line-height: 40px;
+      color: var(--ha-picture-card-text-color, white);
     }
 
     ha-icon-button {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Test code:
```
camera_view: auto
type: picture-glance
title: Kitchen
image: /local/images/test/blue.jpg
entities:
  - entity: input_boolean.test_boolean
  - entity: sun.sun
  - entity: sun.sun
  - entity: input_boolean.test_boolean
```

1. Icons were misaligned:
Before:
![image](https://github.com/user-attachments/assets/75a8f2e5-4106-4f6a-8cd3-343432c81e52)

Better visible with `mdi:circle`:
![image](https://github.com/user-attachments/assets/fd050019-8df4-462c-9e6f-096daa46c295)

After:
![image](https://github.com/user-attachments/assets/c83529fe-b50b-4e94-8067-9ee4494bf70f)
![image](https://github.com/user-attachments/assets/b570d13e-5fae-4d92-9d96-eea115495c57)

Preferred to fix a `font-size` for `picture-glance` only (not globally for all `ha-state-icon` elements).

2. Long title was not cut & causing some icons not displayed.
Before:
![image](https://github.com/user-attachments/assets/6f657ee6-af24-4764-a1af-10272ea96a83)

Seems that these lines did not work for `.title`:
![image](https://github.com/user-attachments/assets/fbd1caf4-0d2e-4d68-87c7-b2710becbad7)

After:
![image](https://github.com/user-attachments/assets/5486ea67-f0f2-4a58-b3cd-34500e182ae6)

3. Title was misaligned:
Before:
![image](https://github.com/user-attachments/assets/46e30fd7-42d2-4da6-b008-7ad5e3b1c00f)

After:
![image](https://github.com/user-attachments/assets/91e75534-4800-4a5c-8c62-867d4518dbed)





## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
