### PR TITLE
Reintroduce backup switch when updating core and addons

### DIFF
--- a/hassio/src/update-available/update-available-card.ts
+++ b/hassio/src/update-available/update-available-card.ts
@@ -9,6 +9,7 @@ import {
 } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { atLeastVersion } from "../../../src/common/config/version";
 import { fireEvent } from "../../../src/common/dom/fire_event";
 import "../../../src/components/buttons/ha-progress-button";
 import "../../../src/components/ha-alert";
@@ -18,7 +19,11 @@ import "../../../src/components/ha-checkbox";
 import "../../../src/components/ha-faded";
 import "../../../src/components/ha-icon-button";
 import "../../../src/components/ha-markdown";
+import "../../../src/components/ha-md-list";
+import "../../../src/components/ha-md-list-item";
 import "../../../src/components/ha-svg-icon";
+import "../../../src/components/ha-switch";
+import type { HaSwitch } from "../../../src/components/ha-switch";
 import type { HassioAddonDetails } from "../../../src/data/hassio/addon";
 import {
   fetchHassioAddonChangelog,
@@ -121,6 +126,8 @@ class UpdateAvailableCard extends LitElement {
 
     const changelog = changelogUrl(this._updateType, this._version_latest);
 
+    const createBackupTexts = this._computeCreateBackupTexts();
+
     return html`
       <ha-card
         outlined
@@ -160,6 +167,30 @@ class UpdateAvailableCard extends LitElement {
                       )}
                     </p>
                   </div>
+                  ${createBackupTexts
+                    ? html`
+                        <hr />
+                        <ha-md-list>
+                          <ha-md-list-item>
+                            <span slot="headline">
+                              ${createBackupTexts.title}
+                            </span>
+
+                            ${createBackupTexts.description
+                              ? html`
+                                  <span slot="supporting-text">
+                                    ${createBackupTexts.description}
+                                  </span>
+                                `
+                              : nothing}
+                            <ha-switch
+                              slot="end"
+                              id="create-backup"
+                            ></ha-switch>
+                          </ha-md-list-item>
+                        </ha-md-list>
+                      `
+                    : nothing}
                 `
               : html`<ha-circular-progress
                     aria-label="Updating"
@@ -225,6 +256,48 @@ class UpdateAvailableCard extends LitElement {
         this._loadOsData();
         break;
     }
+  }
+
+  private _computeCreateBackupTexts():
+    | { title: string; description?: string }
+    | undefined {
+    // Addon backup
+    if (
+      this._updateType === "addon" &&
+      atLeastVersion(this.hass.config.version, 2025, 2, 0)
+    ) {
+      const version = this._version;
+      return {
+        title: this.supervisor.localize("update_available.create_backup.addon"),
+        description: this.supervisor.localize(
+          "update_available.create_backup.addon_description",
+          { version: version }
+        ),
+      };
+    }
+
+    // Old behavior
+    if (this._updateType && ["core", "addon"].includes(this._updateType)) {
+      return {
+        title: this.supervisor.localize(
+          "update_available.create_backup.generic"
+        ),
+      };
+    }
+    return undefined;
+  }
+
+  get _shouldCreateBackup(): boolean {
+    if (this._updateType && !["core", "addon"].includes(this._updateType)) {
+      return false;
+    }
+    const createBackupSwitch = this.shadowRoot?.getElementById(
+      "create-backup"
+    ) as HaSwitch;
+    if (createBackupSwitch) {
+      return createBackupSwitch.checked;
+    }
+    return true;
   }
 
   get _version(): string {
@@ -341,14 +414,22 @@ class UpdateAvailableCard extends LitElement {
   }
 
   private async _update() {
+    if (this._shouldCreateBackup && this.supervisor.info.state === "freeze") {
+      this._error = this.supervisor.localize("backup.backup_already_running");
+      return;
+    }
     this._error = undefined;
     this._updating = true;
 
     try {
       if (this._updateType === "addon") {
-        await updateHassioAddon(this.hass, this.addonSlug!);
+        await updateHassioAddon(
+          this.hass,
+          this.addonSlug!,
+          this._shouldCreateBackup
+        );
       } else if (this._updateType === "core") {
-        await updateCore(this.hass);
+        await updateCore(this.hass, this._shouldCreateBackup);
       } else if (this._updateType === "os") {
         await updateOS(this.hass);
       } else if (this._updateType === "supervisor") {
@@ -402,6 +483,17 @@ class UpdateAvailableCard extends LitElement {
           border-color: var(--divider-color);
           border-bottom: none;
           margin: 16px 0 0 0;
+        }
+
+        ha-md-list {
+          padding: 0;
+          margin-bottom: -16px;
+        }
+
+        ha-md-list-item {
+          --md-list-item-leading-space: 0;
+          --md-list-item-trailing-space: 0;
+          --md-item-overflow: visible;
         }
       `,
     ];

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -313,7 +313,8 @@ export const installHassioAddon = async (
 
 export const updateHassioAddon = async (
   hass: HomeAssistant,
-  slug: string
+  slug: string,
+  backup: boolean
 ): Promise<void> => {
   if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
     await hass.callWS({
@@ -321,11 +322,13 @@ export const updateHassioAddon = async (
       endpoint: `/store/addons/${slug}/update`,
       method: "post",
       timeout: null,
+      data: { backup },
     });
   } else {
     await hass.callApi<HassioResponse<void>>(
       "POST",
-      `hassio/addons/${slug}/update`
+      `hassio/addons/${slug}/update`,
+      { backup }
     );
   }
 };

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -316,7 +316,13 @@ export const updateHassioAddon = async (
   slug: string,
   backup: boolean
 ): Promise<void> => {
-  if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
+  if (atLeastVersion(hass.config.version, 2025, 2, 0)) {
+    await hass.callWS({
+      type: "hassio/update/addon",
+      addon: slug,
+      backup: backup,
+    });
+  } else if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
     await hass.callWS({
       type: "supervisor/api",
       endpoint: `/store/addons/${slug}/update`,

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -322,7 +322,10 @@ export const updateHassioAddon = async (
       addon: slug,
       backup: backup,
     });
-  } else if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
+    return;
+  }
+
+  if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
     await hass.callWS({
       type: "supervisor/api",
       endpoint: `/store/addons/${slug}/update`,
@@ -330,13 +333,14 @@ export const updateHassioAddon = async (
       timeout: null,
       data: { backup },
     });
-  } else {
-    await hass.callApi<HassioResponse<void>>(
-      "POST",
-      `hassio/addons/${slug}/update`,
-      { backup }
-    );
+    return;
   }
+
+  await hass.callApi<HassioResponse<void>>(
+    "POST",
+    `hassio/addons/${slug}/update`,
+    { backup }
+  );
 };
 
 export const restartHassioAddon = async (

--- a/src/data/supervisor/core.ts
+++ b/src/data/supervisor/core.ts
@@ -7,6 +7,15 @@ export const restartCore = async (hass: HomeAssistant) => {
 };
 
 export const updateCore = async (hass: HomeAssistant, backup: boolean) => {
+  if (atLeastVersion(hass.config.version, 2025, 2, 0)) {
+    await hass.callWS({
+      type: "hassio/update/core",
+      backup: backup,
+      version: null,
+    });
+    return;
+  }
+
   if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
     await hass.callWS({
       type: "supervisor/api",
@@ -15,9 +24,10 @@ export const updateCore = async (hass: HomeAssistant, backup: boolean) => {
       timeout: null,
       data: { backup },
     });
-  } else {
-    await hass.callApi<HassioResponse<void>>("POST", "hassio/core/update", {
-      backup,
-    });
+    return;
   }
+
+  await hass.callApi<HassioResponse<void>>("POST", "hassio/core/update", {
+    backup,
+  });
 };

--- a/src/data/supervisor/core.ts
+++ b/src/data/supervisor/core.ts
@@ -6,15 +6,18 @@ export const restartCore = async (hass: HomeAssistant) => {
   await hass.callService("homeassistant", "restart");
 };
 
-export const updateCore = async (hass: HomeAssistant) => {
+export const updateCore = async (hass: HomeAssistant, backup: boolean) => {
   if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
     await hass.callWS({
       type: "supervisor/api",
       endpoint: "/core/update",
       method: "post",
       timeout: null,
+      data: { backup },
     });
   } else {
-    await hass.callApi<HassioResponse<void>>("POST", "hassio/core/update");
+    await hass.callApi<HassioResponse<void>>("POST", "hassio/core/update", {
+      backup,
+    });
   }
 };

--- a/src/data/supervisor/core.ts
+++ b/src/data/supervisor/core.ts
@@ -11,7 +11,6 @@ export const updateCore = async (hass: HomeAssistant, backup: boolean) => {
     await hass.callWS({
       type: "hassio/update/core",
       backup: backup,
-      version: null,
     });
     return;
   }

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -216,14 +216,12 @@ export const isAddonUpdate = (
   if (domain !== "hassio") {
     return false;
   }
-  if (!stateObj.attributes.title) {
-    return true;
-  }
+  const title = stateObj.attributes.title || "";
   return ![
     HOME_ASSISTANT_CORE_TITLE,
     HOME_ASSISTANT_SUPERVISOR_TITLE,
     HOME_ASSISTANT_OS_TITLE,
-  ].includes(stateObj.attributes.title);
+  ].includes(title);
 };
 
 export const isHomeAssistantUpdate = (
@@ -235,5 +233,6 @@ export const isHomeAssistantUpdate = (
   if (domain !== "hassio") {
     return false;
   }
-  return stateObj.attributes.title === HOME_ASSISTANT_CORE_TITLE;
+  const title = stateObj.attributes.title || "";
+  return title === HOME_ASSISTANT_CORE_TITLE;
 };

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -13,6 +13,7 @@ import { caseInsensitiveStringCompare } from "../common/string/compare";
 import { showAlertDialog } from "../dialogs/generic/show-dialog-box";
 import type { HomeAssistant } from "../types";
 import { showToast } from "../util/toast";
+import type { EntitySources } from "./entity_sources";
 
 export enum UpdateEntityFeature {
   INSTALL = 1,
@@ -60,6 +61,10 @@ export const updateReleaseNotes = (hass: HomeAssistant, entityId: string) =>
     entity_id: entityId,
   });
 
+const HOME_ASSISTANT_CORE_TITLE = "Home Assistant Core";
+const HOME_ASSISTANT_SUPERVISOR_TITLE = "Home Assistant Supervisor";
+const HOME_ASSISTANT_OS_TITLE = "Home Assistant Operating System";
+
 export const filterUpdateEntities = (
   entities: HassEntities,
   language?: string
@@ -69,22 +74,22 @@ export const filterUpdateEntities = (
       (entity) => computeStateDomain(entity) === "update"
     ) as UpdateEntity[]
   ).sort((a, b) => {
-    if (a.attributes.title === "Home Assistant Core") {
+    if (a.attributes.title === HOME_ASSISTANT_CORE_TITLE) {
       return -3;
     }
-    if (b.attributes.title === "Home Assistant Core") {
+    if (b.attributes.title === HOME_ASSISTANT_CORE_TITLE) {
       return 3;
     }
-    if (a.attributes.title === "Home Assistant Operating System") {
+    if (a.attributes.title === HOME_ASSISTANT_OS_TITLE) {
       return -2;
     }
-    if (b.attributes.title === "Home Assistant Operating System") {
+    if (b.attributes.title === HOME_ASSISTANT_OS_TITLE) {
       return 2;
     }
-    if (a.attributes.title === "Home Assistant Supervisor") {
+    if (a.attributes.title === HOME_ASSISTANT_SUPERVISOR_TITLE) {
       return -1;
     }
-    if (b.attributes.title === "Home Assistant Supervisor") {
+    if (b.attributes.title === HOME_ASSISTANT_SUPERVISOR_TITLE) {
       return 1;
     }
     return caseInsensitiveStringCompare(
@@ -200,4 +205,35 @@ export const computeUpdateStateDisplay = (
   }
 
   return hass.formatEntityState(stateObj);
+};
+
+export const isAddonUpdate = (
+  stateObj: UpdateEntity,
+  entitySources: EntitySources
+): boolean => {
+  const entity_id = stateObj.entity_id;
+  const domain = entitySources[entity_id]?.domain;
+  if (domain !== "hassio") {
+    return false;
+  }
+  if (!stateObj.attributes.title) {
+    return true;
+  }
+  return ![
+    HOME_ASSISTANT_CORE_TITLE,
+    HOME_ASSISTANT_SUPERVISOR_TITLE,
+    HOME_ASSISTANT_OS_TITLE,
+  ].includes(stateObj.attributes.title);
+};
+
+export const isHomeAssistantUpdate = (
+  stateObj: UpdateEntity,
+  entitySources: EntitySources
+): boolean => {
+  const entity_id = stateObj.entity_id;
+  const domain = entitySources[entity_id]?.domain;
+  if (domain !== "hassio") {
+    return false;
+  }
+  return stateObj.attributes.title === HOME_ASSISTANT_CORE_TITLE;
 };

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -207,32 +207,31 @@ export const computeUpdateStateDisplay = (
   return hass.formatEntityState(stateObj);
 };
 
-export const isAddonUpdate = (
-  stateObj: UpdateEntity,
-  entitySources: EntitySources
-): boolean => {
-  const entity_id = stateObj.entity_id;
-  const domain = entitySources[entity_id]?.domain;
-  if (domain !== "hassio") {
-    return false;
-  }
-  const title = stateObj.attributes.title || "";
-  return ![
-    HOME_ASSISTANT_CORE_TITLE,
-    HOME_ASSISTANT_SUPERVISOR_TITLE,
-    HOME_ASSISTANT_OS_TITLE,
-  ].includes(title);
-};
+type UpdateType = "addon" | "home_assistant" | "generic";
 
-export const isHomeAssistantUpdate = (
+export const getUpdateType = (
   stateObj: UpdateEntity,
   entitySources: EntitySources
-): boolean => {
+): UpdateType => {
   const entity_id = stateObj.entity_id;
   const domain = entitySources[entity_id]?.domain;
   if (domain !== "hassio") {
-    return false;
+    return "generic";
   }
+
   const title = stateObj.attributes.title || "";
-  return title === HOME_ASSISTANT_CORE_TITLE;
+  if (title === HOME_ASSISTANT_CORE_TITLE) {
+    return "home_assistant";
+  }
+
+  if (
+    ![
+      HOME_ASSISTANT_CORE_TITLE,
+      HOME_ASSISTANT_SUPERVISOR_TITLE,
+      HOME_ASSISTANT_OS_TITLE,
+    ].includes(title)
+  ) {
+    return "addon";
+  }
+  return "generic";
 };

--- a/src/dialogs/more-info/controls/more-info-update.ts
+++ b/src/dialogs/more-info/controls/more-info-update.ts
@@ -92,6 +92,7 @@ class MoreInfoUpdate extends LitElement {
         ? new Date(this._backupConfig?.last_completed_automatic_backup)
         : null;
       const now = new Date();
+
       return {
         title: this.hass.localize(
           "ui.dialogs.more_info_control.update.create_backup.automatic"
@@ -343,9 +344,9 @@ class MoreInfoUpdate extends LitElement {
     }
   }
 
-  get _shouldCreateBackup(): boolean | null {
+  get _shouldCreateBackup(): boolean {
     if (!supportsFeature(this.stateObj!, UpdateEntityFeature.BACKUP)) {
-      return null;
+      return false;
     }
     const createBackupSwitch = this.shadowRoot?.getElementById(
       "create-backup"

--- a/src/dialogs/more-info/controls/more-info-update.ts
+++ b/src/dialogs/more-info/controls/more-info-update.ts
@@ -22,8 +22,7 @@ import type { EntitySources } from "../../../data/entity_sources";
 import { fetchEntitySourcesWithCache } from "../../../data/entity_sources";
 import type { UpdateEntity } from "../../../data/update";
 import {
-  isAddonUpdate,
-  isHomeAssistantUpdate,
+  getUpdateType,
   UpdateEntityFeature,
   updateIsInstalling,
   updateReleaseNotes,
@@ -66,11 +65,12 @@ class MoreInfoUpdate extends LitElement {
       return undefined;
     }
 
+    const updateType = this._entitySources
+      ? getUpdateType(this.stateObj, this._entitySources)
+      : "generic";
+
     // Automatic or manual for Home Assistant update
-    if (
-      this._entitySources &&
-      isHomeAssistantUpdate(this.stateObj, this._entitySources)
-    ) {
+    if (updateType === "home_assistant") {
       const isBackupConfigValid =
         !!this._backupConfig &&
         !!this._backupConfig.create_backup.password &&
@@ -116,10 +116,7 @@ class MoreInfoUpdate extends LitElement {
     }
 
     // Addon backup
-    if (
-      this._entitySources &&
-      isAddonUpdate(this.stateObj, this._entitySources)
-    ) {
+    if (updateType === "addon") {
       const version = this.stateObj.attributes.installed_version;
       return {
         title: this.hass.localize(
@@ -320,7 +317,8 @@ class MoreInfoUpdate extends LitElement {
     }
     if (supportsFeature(this.stateObj!, UpdateEntityFeature.BACKUP)) {
       this._fetchEntitySources().then(() => {
-        if (isHomeAssistantUpdate(this.stateObj!, this._entitySources!)) {
+        const type = getUpdateType(this.stateObj!, this._entitySources!);
+        if (type === "home_assistant") {
           this._fetchBackupConfig();
         }
       });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1277,7 +1277,17 @@
           "install": "Install",
           "update": "Update",
           "auto_update_enabled_title": "Can not skip version",
-          "auto_update_enabled_text": "Automatic updates for this item have been enabled; skipping it is, therefore, unavailable. You can either install this update now or wait for Home Assistant to do it automatically."
+          "auto_update_enabled_text": "Automatic updates for this item have been enabled; skipping it is, therefore, unavailable. You can either install this update now or wait for Home Assistant to do it automatically.",
+          "create_backup": {
+            "automatic": "Automatic backup before update",
+            "automatic_description_last": "Last automatic backup {relative_time}.",
+            "automatic_description_none": "No automatic backup yet.",
+            "manual": "Create manual backup before update",
+            "manual_description": "Includes Home Assistant settings and history.",
+            "addon": "Keep backup of the last version",
+            "addon_description": "For easily restoring to version {version}.",
+            "generic": "Create backup"
+          }
         },
         "updater": {
           "title": "Update instructions"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8471,7 +8471,12 @@
       "open_release_notes": "Open release notes",
       "description": "You have {version} installed. Press update to update to version {newest_version}",
       "updating": "Updating {name} to version {version}",
-      "no_update": "No update available for {name}"
+      "no_update": "No update available for {name}",
+      "create_backup": {
+        "addon": "[%key:ui::dialogs::more_info_control::update::create_backup::addon%]",
+        "addon_description": "[%key:ui::dialogs::more_info_control::update::create_backup::addon_description%]",
+        "generic": "[%key:ui::dialogs::more_info_control::update::create_backup::generic%]"
+      }
     },
     "confirm": {
       "restart": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1285,7 +1285,7 @@
             "manual": "Create manual backup before update",
             "manual_description": "Includes Home Assistant settings and history.",
             "addon": "Keep backup of the last version",
-            "addon_description": "For easily restoring to version {version}.",
+            "addon_description": "For easily restoring to version {version}",
             "generic": "Create backup"
           }
         },


### PR DESCRIPTION
## Proposed change

Core PR: 
- https://github.com/home-assistant/core/pull/136235

Re-introduce the backup switch when updating core or an addon : 
- in the more info
- in the addon page

### Trigger automatic backup when updating core
![CleanShot 2025-01-20 at 17 13 41](https://github.com/user-attachments/assets/c9ef8765-9561-4c12-ae73-8490a7986f5c)

### Create "add-on" backup when updating add-on (more info)
![CleanShot 2025-01-20 at 17 13 19](https://github.com/user-attachments/assets/c18b949d-fb4d-459c-aa19-ef788449b2d0)

### Create "add-on" backup when updating add-on (add-on page)
![CleanShot 2025-01-20 at 18 28 52](https://github.com/user-attachments/assets/4ec8a250-829a-4c1a-98fc-a598116a8191)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
