### PR TITLE
Logbook card loading fix

### DIFF
--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -76,7 +76,7 @@ export class HaLogbook extends LitElement {
 
   @state() private _error?: string;
 
-  private _subscribed?: Promise<(() => Promise<void>) | undefined>;
+  private _subscribed?: (() => Promise<void>) | undefined;
 
   private _liveUpdatesEnabled = true;
 
@@ -211,7 +211,7 @@ export class HaLogbook extends LitElement {
   private async _unsubscribe(): Promise<void> {
     if (this._subscribed) {
       try {
-        const unsub = await this._subscribed;
+        const unsub = this._subscribed;
         if (unsub) {
           await unsub();
           this._subscribed = undefined;
@@ -288,7 +288,7 @@ export class HaLogbook extends LitElement {
     if (this._subscribed) {
       return true;
     }
-    this._subscribed = subscribeLogbook(
+    this._subscribed = await subscribeLogbook(
       this.hass,
       (streamMessage) => {
         // "recent" means start time is a sliding window

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -288,8 +288,6 @@ export class HaLogbook extends LitElement {
     if (this._subscribed) {
       return true;
     }
-    // Ensure any previous subscription is cleaned up
-    await this._unsubscribe();
     this._subscribed = subscribeLogbook(
       this.hass,
       (streamMessage) => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This PR fixes an issue I've been having at least the last 6 months. On one of my dashboards the logbook card consistently fails to load the first time. It just spins forever. Changing to another page then coming back to the page loads the card correctly, which is why I've just been putting up with it until now.

This appears to be a race condition. If I put the logbook card by itself on a view then it loads correctly. I only experience this issue if the logbook card is in a view with many other cards.

I've attached a screen recording of the bug in action. When I click on the "Pool" view you will see the "Pool Activity" card just spinning. When I go back to the "Home" view then back to the "Pool" view you can see the "Pool Activity" loaded. I only stayed on the "Pool" view for a few seconds in this video but you can leave it forever and the card will never load.

https://github.com/user-attachments/assets/7ffc8fcc-c4e2-45ce-826d-5e8545813350

The first commit removes a call to this._unsubscribe();. That function does nothing if this._subscribed is undefined, and the code right before this call returns if this._subscribed is undefined so the call to unsubscribe will never do anything.

The second commit adds an await to the call to subscribeLogbook, which is what actually fixes the bug. This changes the type of this._subscribed which is no longer a Promise.

It does seem that the original code should work fine and this change should result in identical behavior (we just moved the await from _unsubscribe to _subscribeLogbookPeriod) so i can't really explain why this fixes the problem but it does.

I was concerned that adding the await in _subscribeLogbookPeriod might end up blocking the page load or something, so I tested by adding an artificial 5 second delay before the call to subscribeLogbook. This causes the logbook card to spin for 5 seconds before loading (as expected) but the rest of the page loaded and functioned with no discernable issues.



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
