### PR TITLE
Display year in entities list only when last year

### DIFF
--- a/src/common/datetime/format_date_time.ts
+++ b/src/common/datetime/format_date_time.ts
@@ -65,6 +65,18 @@ const formatShortDateTimeMem = memoizeOne(
     })
 );
 
+export const formatShortDateTimeWithConditionalYear = (
+  dateObj: Date,
+  locale: FrontendLocaleData,
+  config: HassConfig
+) => {
+  const now = new Date();
+  if (now.getFullYear() === dateObj.getFullYear()) {
+    return formatShortDateTime(dateObj, locale, config);
+  }
+  return formatShortDateTimeWithYear(dateObj, locale, config);
+};
+
 // August 9, 2021, 8:23:15 AM
 export const formatDateTimeWithSeconds = (
   dateObj: Date,

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -23,10 +23,7 @@ import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import memoize from "memoize-one";
 import { computeCssColor } from "../../../common/color/compute-color";
-import {
-  formatShortDateTime,
-  formatShortDateTimeWithYear,
-} from "../../../common/datetime/format_date_time";
+import { formatShortDateTimeWithConditionalYear } from "../../../common/datetime/format_date_time";
 import { storage } from "../../../common/decorators/storage";
 import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
@@ -411,27 +408,14 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         sortable: true,
         filterable: true,
         minWidth: "128px",
-        template: (entry) => {
-          if (!entry.created_at) {
-            return "—";
-          }
-
-          const createdAt = new Date(entry.created_at * 1000);
-          const wasLastYear =
-            createdAt.getFullYear() < new Date().getFullYear();
-
-          return wasLastYear
-            ? formatShortDateTimeWithYear(
-                createdAt,
+        template: (entry) =>
+          entry.created_at
+            ? formatShortDateTimeWithConditionalYear(
+                new Date(entry.created_at * 1000),
                 this.hass.locale,
                 this.hass.config
               )
-            : formatShortDateTime(
-                createdAt,
-                this.hass.locale,
-                this.hass.config
-              );
-        },
+            : "-",
       },
       modified_at: {
         title: localize("ui.panel.config.generic.headers.modified_at"),
@@ -439,27 +423,14 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         sortable: true,
         filterable: true,
         minWidth: "128px",
-        template: (entry) => {
-          if (!entry.modified_at) {
-            return "—";
-          }
-
-          const modifiedAt = new Date(entry.modified_at * 1000);
-          const wasLastYear =
-            modifiedAt.getFullYear() < new Date().getFullYear();
-
-          return wasLastYear
-            ? formatShortDateTimeWithYear(
-                modifiedAt,
+        template: (entry) =>
+          entry.modified_at
+            ? formatShortDateTimeWithConditionalYear(
+                new Date(entry.modified_at * 1000),
                 this.hass.locale,
                 this.hass.config
               )
-            : formatShortDateTime(
-                modifiedAt,
-                this.hass.locale,
-                this.hass.config
-              );
-        },
+            : "-",
       },
       available: {
         title: localize("ui.panel.config.entities.picker.headers.availability"),

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -23,7 +23,10 @@ import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import memoize from "memoize-one";
 import { computeCssColor } from "../../../common/color/compute-color";
-import { formatShortDateTimeWithYear } from "../../../common/datetime/format_date_time";
+import {
+  formatShortDateTime,
+  formatShortDateTimeWithYear,
+} from "../../../common/datetime/format_date_time";
 import { storage } from "../../../common/decorators/storage";
 import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
@@ -408,14 +411,27 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         sortable: true,
         filterable: true,
         minWidth: "128px",
-        template: (entry) =>
-          entry.created_at
+        template: (entry) => {
+          if (!entry.created_at) {
+            return "—";
+          }
+
+          const createdAt = new Date(entry.created_at * 1000);
+          const wasLastYear =
+            createdAt.getFullYear() < new Date().getFullYear();
+
+          return wasLastYear
             ? formatShortDateTimeWithYear(
-                new Date(entry.created_at * 1000),
+                createdAt,
                 this.hass.locale,
                 this.hass.config
               )
-            : "—",
+            : formatShortDateTime(
+                createdAt,
+                this.hass.locale,
+                this.hass.config
+              );
+        },
       },
       modified_at: {
         title: localize("ui.panel.config.generic.headers.modified_at"),
@@ -423,14 +439,27 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         sortable: true,
         filterable: true,
         minWidth: "128px",
-        template: (entry) =>
-          entry.modified_at
+        template: (entry) => {
+          if (!entry.modified_at) {
+            return "—";
+          }
+
+          const modifiedAt = new Date(entry.modified_at * 1000);
+          const wasLastYear =
+            modifiedAt.getFullYear() < new Date().getFullYear();
+
+          return wasLastYear
             ? formatShortDateTimeWithYear(
-                new Date(entry.modified_at * 1000),
+                modifiedAt,
                 this.hass.locale,
                 this.hass.config
               )
-            : "—",
+            : formatShortDateTime(
+                modifiedAt,
+                this.hass.locale,
+                this.hass.config
+              );
+        },
       },
       available: {
         title: localize("ui.panel.config.entities.picker.headers.availability"),

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -415,7 +415,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
                 this.hass.locale,
                 this.hass.config
               )
-            : "-",
+            : "—",
       },
       modified_at: {
         title: localize("ui.panel.config.generic.headers.modified_at"),
@@ -430,7 +430,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
                 this.hass.locale,
                 this.hass.config
               )
-            : "-",
+            : "—",
       },
       available: {
         title: localize("ui.panel.config.entities.picker.headers.availability"),


### PR DESCRIPTION
## Proposed change
Only display the year of the modified at/created at date when is not the current year.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
