### PR TITLE
Increase generic entity row touch target

### DIFF
--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -195,11 +195,15 @@ export class HuiGenericEntityRow extends LitElement {
       flex-direction: row;
     }
     .info {
-      margin-left: 16px;
-      margin-right: 8px;
-      margin-inline-start: 16px;
-      margin-inline-end: 8px;
+      padding-left: 16px;
+      padding-right: 8px;
+      padding-inline-start: 16px;
+      padding-inline-end: 8px;
       flex: 1 1 30%;
+      min-height: 40px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
     }
     .info,
     .info > * {
@@ -233,6 +237,9 @@ export class HuiGenericEntityRow extends LitElement {
     }
     .value {
       direction: ltr;
+      min-height: 40px;
+      display: flex;
+      align-items: center;
     }
   `;
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR implements the suggestions of #18461 and increases the touch target size of the generic entity row. This is accomplished by setting the minimum height of the entire row to that of the state badge, which is fixed to 40px. Additionally it changes the margin of the info text to be padding instead, in order to remove the gaps in the touchable area.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18461
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
