### PR TITLE
Update settings button icon on tables to mdi-table-cog.

### DIFF
--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -5,7 +5,7 @@ import {
   mdiArrowDown,
   mdiArrowUp,
   mdiClose,
-  mdiCog,
+  mdiTableCog,
   mdiFilterVariant,
   mdiFilterVariantRemove,
   mdiFormatListChecks,
@@ -309,7 +309,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
       @click=${this._openSettings}
       .title=${localize("ui.components.subpage-data-table.settings")}
     >
-      <ha-svg-icon slot="icon" .path=${mdiCog}></ha-svg-icon>
+      <ha-svg-icon slot="icon" .path=${mdiTableCog}></ha-svg-icon>
     </ha-assist-chip>`;
 
     return html`

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -3,7 +3,7 @@ import {
   mdiArrowDown,
   mdiArrowUp,
   mdiClose,
-  mdiCog,
+  mdiTableCog,
   mdiFormatListChecks,
   mdiMenuDown,
   mdiSlopeUphill,
@@ -303,7 +303,7 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
       @click=${this._openSettings}
       .title=${localize("ui.components.subpage-data-table.settings")}
     >
-      <ha-svg-icon slot="icon" .path=${mdiCog}></ha-svg-icon>
+      <ha-svg-icon slot="icon" .path=${mdiTableCog}></ha-svg-icon>
     </ha-assist-chip>`;
 
     return html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The cog icon is used in a lot of places to indicate settings and it's generally clear what it's intent is.  However, the cog icon used by tables very often appears very close by the triple dots menu or just in the top right corner so it's very easy to mistakenly press that button intending to press the menu button, or to press it when looking for the appropriate settings button.

This changes the icon used by these buttons from mdi-code to mdi-table-cog to help clarify the intent of the button.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
  - This code was not actually tested, but I assume that since mdi:table-cog show up in the selector UI that this will be valid for react buttons as well.
- [X] There is no commented out code in this PR.