### PR TITLE
Revert "Add shortcut hint to assist dialog"

### DIFF
--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -29,7 +29,6 @@ import { haStyleDialog } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
 import type { VoiceCommandDialogParams } from "./show-ha-voice-command-dialog";
-import "../../components/ha-tip";
 
 @customElement("ha-voice-command-dialog")
 export class HaVoiceCommandDialog extends LitElement {
@@ -52,8 +51,6 @@ export class HaVoiceCommandDialog extends LitElement {
 
   @state() private _errorLoadAssist?: "not_found" | "unknown";
 
-  @state() private _hint?: string;
-
   private _startListening = false;
 
   public async showDialog(
@@ -71,7 +68,6 @@ export class HaVoiceCommandDialog extends LitElement {
 
     this._startListening = params.start_listening;
     this._opened = true;
-    this._hint = params.hint;
   }
 
   public async closeDialog(): Promise<void> {
@@ -189,9 +185,6 @@ export class HaVoiceCommandDialog extends LitElement {
                   size="large"
                 ></ha-circular-progress>
               </div>`}
-        ${this._hint
-          ? html`<ha-tip .hass=${this.hass}>${this._hint}</ha-tip>`
-          : nothing}
       </ha-dialog>
     `;
   }
@@ -254,7 +247,7 @@ export class HaVoiceCommandDialog extends LitElement {
       css`
         ha-dialog {
           --mdc-dialog-max-width: 500px;
-          --mdc-dialog-max-height: 550px;
+          --mdc-dialog-max-height: 500px;
           --dialog-content-padding: 0;
         }
         ha-dialog-header a {
@@ -318,9 +311,6 @@ export class HaVoiceCommandDialog extends LitElement {
         ha-assist-chat {
           margin: 0 24px 16px;
           min-height: 399px;
-        }
-        ha-tip {
-          padding-bottom: 16px;
         }
       `,
     ];

--- a/src/dialogs/voice-command-dialog/show-ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/show-ha-voice-command-dialog.ts
@@ -6,7 +6,6 @@ const loadVoiceCommandDialog = () => import("./ha-voice-command-dialog");
 export interface VoiceCommandDialogParams {
   pipeline_id: "last_used" | "preferred" | string;
   start_listening?: boolean;
-  hint?: string;
 }
 
 export const showVoiceCommandDialog = (
@@ -32,7 +31,6 @@ export const showVoiceCommandDialog = (
       pipeline_id: dialogParams.pipeline_id,
       // Don't start listening by default for web
       start_listening: dialogParams.start_listening ?? false,
-      hint: dialogParams.hint,
     },
   });
 };

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -730,12 +730,7 @@ class HUIRoot extends LitElement {
   }
 
   private _showVoiceCommandDialog(): void {
-    showVoiceCommandDialog(this, this.hass, {
-      pipeline_id: "last_used",
-      hint: this.hass.enableShortcuts
-        ? this.hass.localize("ui.tips.key_a_hint")
-        : undefined,
-    });
+    showVoiceCommandDialog(this, this.hass, { pipeline_id: "last_used" });
   }
 
   private _handleEnableEditMode(ev: CustomEvent<RequestSelectedDetail>): void {


### PR DESCRIPTION
Reverts home-assistant/frontend#23739

@jpbede I am sorry but we going to revert this to don't have it in beta.

Because it takes a lot of space in the dialog and shows everytime. When you are used to use the assist button it could annoy you. Moreover it shows always on mobile, where you normally cannot press the `a` key.

Thanks again for your contribution! @marcinbauer85 may come up with some dismissable tips designs in the future.