### PR TITLE
Open more-info on label click in echarts

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -6,7 +6,11 @@ import { mdiRestart } from "@mdi/js";
 import type { EChartsType } from "echarts/core";
 import type { DataZoomComponentOption } from "echarts/components";
 import { ResizeController } from "@lit-labs/observers/resize-controller";
-import type { XAXisOption, YAXisOption } from "echarts/types/dist/shared";
+import type {
+  ECElementEvent,
+  XAXisOption,
+  YAXisOption,
+} from "echarts/types/dist/shared";
 import { consume } from "@lit-labs/context";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { HomeAssistant } from "../../types";
@@ -197,6 +201,15 @@ export class HaChartBase extends LitElement {
         const { start, end } = e.batch?.[0] ?? e;
         this._isZoomed = start !== 0 || end !== 100;
       });
+      this.chart.on("click", (e: ECElementEvent) => {
+        fireEvent(this, "chart-click", e);
+      });
+      this.chart.on("mousemove", (e: ECElementEvent) => {
+        if (e.componentType === "series" && e.componentSubType === "custom") {
+          // custom series do not support cursor style so we need to set it manually
+          this.chart?.getZr()?.setCursorStyle("default");
+        }
+      });
       this.chart.setOption({ ...this._createOptions(), series: this.data });
     } finally {
       this._loading = false;
@@ -318,5 +331,6 @@ declare global {
   interface HASSDomEvents {
     "dataset-hidden": { name: string };
     "dataset-unhidden": { name: string };
+    "chart-click": ECElementEvent;
   }
 }

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -316,6 +316,7 @@ export class StateHistoryChartLine extends LitElement {
           id: nameY,
           data: [],
           type: "line",
+          cursor: "default",
           name: nameY,
           color,
           symbol: "circle",

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -4,6 +4,7 @@ import { customElement, property, state } from "lit/decorators";
 import type {
   CustomSeriesOption,
   CustomSeriesRenderItem,
+  ECElementEvent,
   TooltipFormatterCallback,
   TooltipPositionCallbackParams,
 } from "echarts/types/dist/shared";
@@ -67,6 +68,7 @@ export class StateHistoryChartTimeline extends LitElement {
         .options=${this._chartOptions}
         .height=${`${this.data.length * 30 + 30}px`}
         .data=${this._chartData}
+        @chart-click=${this._handleChartClick}
       ></ha-chart-base>
     `;
   }
@@ -215,6 +217,7 @@ export class StateHistoryChartTimeline extends LitElement {
         type: "category",
         inverse: true,
         position: rtl ? "right" : "left",
+        triggerEvent: true,
         axisTick: {
           show: false,
         },
@@ -357,6 +360,17 @@ export class StateHistoryChartTimeline extends LitElement {
     });
 
     this._chartData = datasets;
+  }
+
+  private _handleChartClick(e: CustomEvent<ECElementEvent>): void {
+    if (e.detail.targetType === "axisLabel") {
+      const dataset = this.data[e.detail.dataIndex];
+      if (dataset) {
+        fireEvent(this, "hass-more-info", {
+          entityId: dataset.entity_id,
+        });
+      }
+    }
   }
 
   static styles = css`

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -425,6 +425,7 @@ export class StatisticsChart extends LitElement {
           const series: LineSeriesOption | BarSeriesOption = {
             id: `${statistic_id}-${type}`,
             type: this.chartType,
+            cursor: "default",
             data: [],
             name: name
               ? `${name} (${this.hass.localize(

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -335,6 +335,7 @@ export class HuiEnergyDevicesDetailGraphCard
     });
     const dataset: BarSeriesOption = {
       type: "bar",
+      cursor: "default",
       id: compare ? "compare-untracked" : "untracked",
       name: this.hass.localize(
         "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption"
@@ -417,6 +418,7 @@ export class HuiEnergyDevicesDetailGraphCard
 
       data.push({
         type: "bar",
+        cursor: "default",
         id: compare
           ? `compare-${source.stat_consumption}`
           : source.stat_consumption,

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -17,6 +17,7 @@ import { getEnergyDataCollection } from "../../../../data/energy";
 import {
   calculateStatisticSumGrowth,
   getStatisticLabel,
+  isExternalStatistic,
 } from "../../../../data/recorder";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../../types";
@@ -236,7 +237,11 @@ export class HuiEnergyDevicesGraphCard
   }
 
   private _handleChartClick(e: CustomEvent<ECElementEvent>): void {
-    if (e.detail.targetType === "axisLabel" && e.detail.value) {
+    if (
+      e.detail.targetType === "axisLabel" &&
+      e.detail.value &&
+      !isExternalStatistic(e.detail.value as string)
+    ) {
       fireEvent(this, "hass-more-info", {
         entityId: e.detail.value as string,
       });

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -5,6 +5,7 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
 import type { BarSeriesOption } from "echarts/charts";
+import type { ECElementEvent } from "echarts/types/dist/shared";
 import { getGraphColorByIndex } from "../../../../common/color/colors";
 import {
   formatNumber,
@@ -24,6 +25,7 @@ import type { EnergyDevicesGraphCardConfig } from "../types";
 import { hasConfigChanged } from "../../common/has-changed";
 import type { ECOption } from "../../../../resources/echarts";
 import "../../../../components/ha-card";
+import { fireEvent } from "../../../../common/dom/fire_event";
 
 @customElement("hui-energy-devices-graph-card")
 export class HuiEnergyDevicesGraphCard
@@ -87,6 +89,7 @@ export class HuiEnergyDevicesGraphCard
             .data=${this._chartData}
             .options=${this._createOptions(this.hass.themes?.darkMode)}
             .height=${`${(this._chartData[0]?.data?.length || 0) * 28 + 50}px`}
+            @chart-click=${this._handleChartClick}
           ></ha-chart-base>
         </div>
       </ha-card>
@@ -117,6 +120,7 @@ export class HuiEnergyDevicesGraphCard
       yAxis: {
         type: "category",
         inverse: true,
+        triggerEvent: true,
         axisLabel: {
           formatter: this._getDeviceName.bind(this),
           overflow: "truncate",
@@ -167,6 +171,7 @@ export class HuiEnergyDevicesGraphCard
         },
         data: chartData,
         barWidth: compareData ? 10 : 20,
+        cursor: "default",
       },
     ];
 
@@ -181,6 +186,7 @@ export class HuiEnergyDevicesGraphCard
         },
         data: chartDataCompare,
         barWidth: 10,
+        cursor: "default",
       });
     }
 
@@ -227,6 +233,14 @@ export class HuiEnergyDevicesGraphCard
 
     this._chartData = datasets;
     await this.updateComplete;
+  }
+
+  private _handleChartClick(e: CustomEvent<ECElementEvent>): void {
+    if (e.detail.targetType === "axisLabel" && e.detail.value) {
+      fireEvent(this, "hass-more-info", {
+        entityId: e.detail.value as string,
+      });
+    }
   }
 
   static styles = css`

--- a/src/panels/lovelace/cards/energy/hui-energy-gas-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-gas-graph-card.ts
@@ -248,6 +248,7 @@ export class HuiEnergyGasGraphCard
 
       data.push({
         type: "bar",
+        cursor: "default",
         id: compare
           ? "compare-" + source.stat_energy_from
           : source.stat_energy_from,

--- a/src/panels/lovelace/cards/energy/hui-energy-solar-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-solar-graph-card.ts
@@ -267,6 +267,7 @@ export class HuiEnergySolarGraphCard
 
       data.push({
         type: "bar",
+        cursor: "default",
         id: compare
           ? "compare-" + source.stat_energy_from
           : source.stat_energy_from,

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -502,6 +502,7 @@ export class HuiEnergyUsageGraphCard
         data.push({
           id: compare ? "compare-" + statId : statId,
           type: "bar",
+          cursor: "default",
           name:
             type in labels
               ? labels[type]

--- a/src/panels/lovelace/cards/energy/hui-energy-water-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-water-graph-card.ts
@@ -246,6 +246,7 @@ export class HuiEnergyWaterGraphCard
 
       data.push({
         type: "bar",
+        cursor: "default",
         id: compare
           ? "compare-" + source.stat_energy_from
           : source.stat_energy_from,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Timeline and energy-device-graph charts open more-info on click of the entity name on the left. Line charts still don't have a way to open more-info.
Timeline and bar charts no longer change the cursor to pointer on the bars. Still haven't found a way to fix this for line charts

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
