### PR TITLE
Include addresses of Bluetooth devices in the connection slots tooltip

### DIFF
--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-config-dashboard.ts
@@ -160,7 +160,9 @@ export class BluetoothConfigDashboard extends LitElement {
           "ui.panel.config.bluetooth.used_connection_slot_allocations"
         )}
         .value=${this._getUsedAllocations(allocationsUsed, allocationsTotal)}
-        .tooltip=${`${allocationsUsed}/${allocationsTotal}`}
+        .tooltip=${allocations.allocated.length > 0
+          ? `${allocationsUsed}/${allocationsTotal} (${allocations.allocated.join(", ")})`
+          : `${allocationsUsed}/${allocationsTotal}`}
       ></ha-metric>
     `;
   }


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Include addresses of Bluetooth devices in the connection slots tooltip.  The intent is to make it obvious if there is a device that remains connected for a longer than expected amount of time.  Note that local adapters support this currently and ESPHome 2025.2.x + HA 2025.2.x+ or later is required for the addresses allocated to the connection slots to be known.

If someone has a better suggestion on where to display these, that would be great.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
