### PR TITLE
Align view mount dialog with design guidelines

### DIFF
--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -1,4 +1,4 @@
-import { mdiHelpCircle } from "@mdi/js";
+import { mdiClose, mdiHelpCircle } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -215,6 +215,12 @@ class ViewMountDialog extends LitElement {
         @closed=${this.closeDialog}
       >
         <ha-dialog-header slot="heading">
+          <ha-icon-button
+            slot="navigationIcon"
+            dialogAction="cancel"
+            .label=${this.hass.localize("ui.common.close")}
+            .path=${mdiClose}
+          ></ha-icon-button>
           <span slot="title"
             >${this._existing
               ? this.hass.localize(
@@ -261,30 +267,34 @@ class ViewMountDialog extends LitElement {
           @value-changed=${this._valueChanged}
           dialogInitialFocus
         ></ha-form>
-        <div slot="secondaryAction">
-          <mwc-button @click=${this.closeDialog} dialogInitialFocus>
-            ${this.hass.localize("ui.common.cancel")}
-          </mwc-button>
-          ${this._existing
-            ? html`<mwc-button @click=${this._deleteMount} class="delete-btn">
-                ${this.hass.localize("ui.common.delete")}
-              </mwc-button>`
-            : nothing}
-        </div>
 
-        <ha-progress-button
-          .progress=${this._waiting}
-          slot="primaryAction"
-          @click=${this._connectMount}
-        >
-          ${this._existing
-            ? this.hass.localize(
-                "ui.panel.config.storage.network_mounts.update"
-              )
-            : this.hass.localize(
-                "ui.panel.config.storage.network_mounts.connect"
-              )}
-        </ha-progress-button>
+        ${this._existing
+          ? html`<ha-button
+              @click=${this._deleteMount}
+              destructive
+              slot="secondaryAction"
+            >
+              ${this.hass.localize("ui.common.delete")}
+            </ha-button>`
+          : nothing}
+
+        <div slot="primaryAction">
+          <ha-button @click=${this.closeDialog} dialogInitialFocus>
+            ${this.hass.localize("ui.common.cancel")}
+          </ha-button>
+          <ha-progress-button
+            .progress=${this._waiting}
+            @click=${this._connectMount}
+          >
+            ${this._existing
+              ? this.hass.localize(
+                  "ui.panel.config.storage.network_mounts.update"
+                )
+              : this.hass.localize(
+                  "ui.panel.config.storage.network_mounts.connect"
+                )}
+          </ha-progress-button>
+        </div>
       </ha-dialog>
     `;
   }
@@ -388,9 +398,6 @@ class ViewMountDialog extends LitElement {
       css`
         ha-icon-button {
           color: var(--primary-text-color);
-        }
-        .delete-btn {
-          --mdc-theme-primary: var(--error-color);
         }
       `,
     ];


### PR DESCRIPTION
## Proposed change
Align the view mount dialog with the design guidelines:

- Move the delete button to left
- Move and group the cancel and save button to the right
- Add close button to the top left
- Use `ha-button` instead of `mwc-button`
- Make use of `ha-button`s destructive attribute

![image](https://github.com/user-attachments/assets/6cfc7e5b-60a5-44ab-932c-fbaf3a008771)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
