### PR TITLE
Update ZHA device websocket API types

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -42,20 +42,20 @@ export interface Neighbor {
 }
 
 export interface Route {
-  dest_nwk: string,
-  route_status: RouteStatus,
-  memory_constrained: boolean,
-  many_to_one: boolean,
-  route_record_required: boolean,
-  next_hop: string,
+  dest_nwk: string;
+  route_status: RouteStatus;
+  memory_constrained: boolean;
+  many_to_one: boolean;
+  route_record_required: boolean;
+  next_hop: string;
 }
 
 export enum RouteStatus {
-    Active = "Active",
-    DiscoveryUnderway = "Discovery_Underway",
-    DiscoveryFailed = "Discovery_Failed",
-    Inactive = "Inactive",
-    ValidationUnderway = "Validation_Underway",
+  Active = "Active",
+  DiscoveryUnderway = "Discovery_Underway",
+  DiscoveryFailed = "Discovery_Failed",
+  Inactive = "Inactive",
+  ValidationUnderway = "Validation_Underway",
 }
 
 export interface ZHADeviceEndpoint {

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -29,6 +29,7 @@ export interface ZHADevice {
   active_coordinator: boolean;
   signature: any;
   neighbors: Neighbor[];
+  routes: Route[];
   pairing_status?: string;
 }
 
@@ -38,6 +39,23 @@ export interface Neighbor {
   lqi: string;
   depth: string;
   relationship: string;
+}
+
+export interface Route {
+  dest_nwk: string,
+  route_status: RouteStatus,
+  memory_constrained: boolean,
+  many_to_one: boolean,
+  route_record_required: boolean,
+  next_hop: string,
+}
+
+export enum RouteStatus {
+    Active = "Active",
+    DiscoveryUnderway = "Discovery_Underway",
+    DiscoveryFailed = "Discovery_Failed",
+    Inactive = "Inactive",
+    ValidationUnderway = "Validation_Underway",
 }
 
 export interface ZHADeviceEndpoint {

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -11,8 +11,8 @@ export interface ZHADevice {
   available: boolean;
   name: string;
   ieee: string;
-  nwk: string;
-  lqi: string;
+  nwk: number;
+  lqi: number;
   rssi: string;
   last_seen: string;
   manufacturer: string;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Expose ZHA `Route` objects in the websocket API and clean up some existing types. This has been present in the ZHA websocket API for well over a year now, we just forgot to update frontend.

CC @MindFreeze

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
