### PR TITLE
Fix area registry dialog field

### DIFF
--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -329,6 +329,9 @@ class DialogAreaDetail extends LitElement {
     return [
       haStyleDialog,
       css`
+        ha-textfield {
+          display: block;
+        }
         ha-aliases-editor,
         ha-entity-picker,
         ha-floor-picker,


### PR DESCRIPTION
## Proposed change
The `ha-textfield` was no longer across the entire width of the dialog.

| <img width="590" alt="image" src="https://github.com/user-attachments/assets/5f7330c9-b8f2-4ba3-8d88-bc5fcbbc6dc4" /> | <img width="584" alt="image" src="https://github.com/user-attachments/assets/c888c0cb-3e30-454a-9e8d-0f409b547dd9" /> |
|:-:|:-:|

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
