### PR TITLE
Display hold and double tap actions in tile card editor if they are set

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7111,6 +7111,8 @@
               "color": "Color",
               "color_helper": "Inactive state (e.g. off, closed) will not be colored.",
               "icon_tap_action": "Icon tap behavior",
+              "icon_hold_action": "Icon hold behavior",
+              "icon_double_tap_action": "Icon double tap behavior",
               "interactions": "Interactions",
               "appearance": "Appearance",
               "show_entity_picture": "Show entity picture",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Hold action will not be display in the UI by default for tile card.

## Proposed change

Before this changes, if you were using `icon_hold_action`, `icon_double_tap_action` and `double_tap_action`, the editor will switch to `yaml` mode.

With this change, the new actions fields will be added to the UI is they have been previously configured in `yaml`.

Also, the hold action has been removed from the UI by default before it is not really discoverable and not accessible.

### Default actions

![CleanShot 2025-02-11 at 12 31 31](https://github.com/user-attachments/assets/7d7d064f-6ffe-4aec-8e96-8307a6e8157c)

### All possible actions configured

![CleanShot 2025-02-11 at 12 35 03](https://github.com/user-attachments/assets/318071c6-ffe5-4f37-b433-0ebb65beaba4)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
