### PR TITLE
Save theme by user

### DIFF
--- a/src/data/ws-themes.ts
+++ b/src/data/ws-themes.ts
@@ -1,5 +1,11 @@
 import type { Connection } from "home-assistant-js-websocket";
 import { createCollection } from "home-assistant-js-websocket";
+import type { HomeAssistant, ThemeSettings } from "../types";
+import {
+  fetchFrontendUserData,
+  saveFrontendUserData,
+  subscribeFrontendUserData,
+} from "./frontend";
 
 export interface ThemeVars {
   // Incomplete
@@ -50,3 +56,16 @@ export const subscribeThemes = (
     conn,
     onChange
   );
+
+export const SELECTED_THEME_KEY = "selectedTheme";
+
+export const saveSelectedTheme = (hass: HomeAssistant, data?: ThemeSettings) =>
+  saveFrontendUserData(hass.connection, SELECTED_THEME_KEY, data);
+
+export const subscribeSelectedTheme = (
+  hass: HomeAssistant,
+  callback: (selectedTheme?: ThemeSettings | null) => void
+) => subscribeFrontendUserData(hass.connection, SELECTED_THEME_KEY, callback);
+
+export const fetchSelectedTheme = (hass: HomeAssistant) =>
+  fetchFrontendUserData(hass.connection, SELECTED_THEME_KEY);

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -20,6 +20,12 @@
     <meta name="color-scheme" content="dark light" />
     <%= renderTemplate("_style_base.html.template") %>
     <style>
+      ::view-transition-old(root),
+      ::view-transition-new(root) {
+        animation: none;
+        mix-blend-mode: normal;
+      }
+
       html {
         background-color: var(--primary-background-color, #fafafa);
         color: var(--primary-text-color, #212121);

--- a/src/panels/profile/ha-pick-theme-row.ts
+++ b/src/panels/profile/ha-pick-theme-row.ts
@@ -16,6 +16,7 @@ import {
 } from "../../resources/styles-data";
 import type { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
+import type { StorageLocation } from "../../state/themes-mixin";
 
 const USE_DEFAULT_THEME = "__USE_DEFAULT_THEME__";
 const HOME_ASSISTANT_THEME = "default";
@@ -25,6 +26,9 @@ export class HaPickThemeRow extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ type: Boolean }) public narrow = false;
+
+  @property({ attribute: false })
+  public storageLocation: StorageLocation = "browser";
 
   @state() _themeNames: string[] = [];
 
@@ -171,13 +175,19 @@ export class HaPickThemeRow extends LitElement {
 
   private _handleColorChange(ev: CustomEvent) {
     const target = ev.target as any;
-    fireEvent(this, "settheme", { [target.name]: target.value });
+    fireEvent(this, "settheme", {
+      settings: { [target.name]: target.value },
+      storageLocation: this.storageLocation,
+    });
   }
 
   private _resetColors() {
     fireEvent(this, "settheme", {
-      primaryColor: undefined,
-      accentColor: undefined,
+      settings: {
+        primaryColor: undefined,
+        accentColor: undefined,
+      },
+      storageLocation: this.storageLocation,
     });
   }
 
@@ -198,7 +208,10 @@ export class HaPickThemeRow extends LitElement {
         dark = true;
         break;
     }
-    fireEvent(this, "settheme", { dark });
+    fireEvent(this, "settheme", {
+      settings: { dark },
+      storageLocation: this.storageLocation,
+    });
   }
 
   private _handleThemeSelection(ev) {
@@ -210,17 +223,23 @@ export class HaPickThemeRow extends LitElement {
     if (theme === USE_DEFAULT_THEME) {
       if (this.hass.selectedTheme?.theme) {
         fireEvent(this, "settheme", {
-          theme: "",
-          primaryColor: undefined,
-          accentColor: undefined,
+          settings: {
+            theme: "",
+            primaryColor: undefined,
+            accentColor: undefined,
+          },
+          storageLocation: this.storageLocation,
         });
       }
       return;
     }
     fireEvent(this, "settheme", {
-      theme,
-      primaryColor: undefined,
-      accentColor: undefined,
+      settings: {
+        theme,
+        primaryColor: undefined,
+        accentColor: undefined,
+      },
+      storageLocation: this.storageLocation,
     });
   }
 

--- a/src/panels/profile/ha-pick-theme-row.ts
+++ b/src/panels/profile/ha-pick-theme-row.ts
@@ -1,11 +1,14 @@
-import "@material/mwc-button/mwc-button";
-import "@material/mwc-list/mwc-list-item";
+import { mdiAlertCircleOutline } from "@mdi/js";
 import type { PropertyValues, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-formfield";
 import "../../components/ha-radio";
+import "../../components/ha-button";
+import "../../components/ha-circular-progress";
+import "../../components/ha-svg-icon";
+import "../../components/ha-list-item";
 import type { HaRadio } from "../../components/ha-radio";
 import "../../components/ha-select";
 import "../../components/ha-settings-row";
@@ -14,9 +17,10 @@ import {
   DEFAULT_ACCENT_COLOR,
   DEFAULT_PRIMARY_COLOR,
 } from "../../resources/styles-data";
-import type { HomeAssistant } from "../../types";
+import type { HomeAssistant, ThemeSettings } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
 import type { StorageLocation } from "../../state/themes-mixin";
+import { subscribeSelectedTheme } from "../../data/ws-themes";
 
 const USE_DEFAULT_THEME = "__USE_DEFAULT_THEME__";
 const HOME_ASSISTANT_THEME = "default";
@@ -32,55 +36,73 @@ export class HaPickThemeRow extends LitElement {
 
   @state() _themeNames: string[] = [];
 
+  @state() private _selectedTheme?: ThemeSettings;
+
+  @state() private _loading = false;
+
   protected render(): TemplateResult {
+    if (this._loading) {
+      return html`<ha-circular-progress indeterminate></ha-circular-progress>`;
+    }
+
     const hasThemes =
       this.hass.themes.themes && Object.keys(this.hass.themes.themes).length;
 
-    const curThemeIsUseDefault = this.hass.selectedTheme?.theme === "";
-    const curTheme = this.hass.selectedTheme?.theme
-      ? this.hass.selectedTheme?.theme
-      : this.hass.themes.darkMode
+    const curThemeIsUseDefault = this._selectedTheme?.theme === "";
+    const curTheme = this._selectedTheme?.theme
+      ? this._selectedTheme?.theme
+      : this._selectedTheme?.dark
         ? this.hass.themes.default_dark_theme || this.hass.themes.default_theme
         : this.hass.themes.default_theme;
-
-    const themeSettings = this.hass.selectedTheme;
 
     return html`
       <ha-settings-row .narrow=${this.narrow}>
         <span slot="heading"
           >${this.hass.localize("ui.panel.profile.themes.header")}</span
         >
-        <span slot="description">
-          ${!hasThemes
+        <span
+          slot="description"
+          class=${this.storageLocation === "user" &&
+          this.hass.browserThemeEnabled
+            ? "device-info"
+            : ""}
+        >
+          ${!hasThemes &&
+          !(this.storageLocation === "user" && this.hass.browserThemeEnabled)
             ? this.hass.localize("ui.panel.profile.themes.error_no_theme")
             : ""}
-          <a
-            href=${documentationUrl(
-              this.hass,
-              "/integrations/frontend/#defining-themes"
-            )}
-            target="_blank"
-            rel="noreferrer"
-          >
-            ${this.hass.localize("ui.panel.profile.themes.link_promo")}
-          </a>
+          ${this.storageLocation === "user" && this.hass.browserThemeEnabled
+            ? html`<ha-svg-icon .path=${mdiAlertCircleOutline}></ha-svg-icon>
+                ${this.hass.localize(
+                  "ui.panel.profile.themes.device.user_theme_info"
+                )}`
+            : html`<a
+                href=${documentationUrl(
+                  this.hass,
+                  "/integrations/frontend/#defining-themes"
+                )}
+                target="_blank"
+                rel="noreferrer"
+              >
+                ${this.hass.localize("ui.panel.profile.themes.link_promo")}
+              </a>`}
         </span>
         <ha-select
           .label=${this.hass.localize("ui.panel.profile.themes.dropdown_label")}
           .disabled=${!hasThemes}
-          .value=${this.hass.selectedTheme?.theme || USE_DEFAULT_THEME}
+          .value=${this._selectedTheme?.theme || USE_DEFAULT_THEME}
           @selected=${this._handleThemeSelection}
           naturalMenuWidth
         >
-          <mwc-list-item .value=${USE_DEFAULT_THEME}>
+          <ha-list-item .value=${USE_DEFAULT_THEME}>
             ${this.hass.localize("ui.panel.profile.themes.use_default")}
-          </mwc-list-item>
-          <mwc-list-item .value=${HOME_ASSISTANT_THEME}>
+          </ha-list-item>
+          <ha-list-item .value=${HOME_ASSISTANT_THEME}>
             Home Assistant
-          </mwc-list-item>
+          </ha-list-item>
           ${this._themeNames.map(
             (theme) => html`
-              <mwc-list-item .value=${theme}>${theme}</mwc-list-item>
+              <ha-list-item .value=${theme}>${theme}</ha-list-item>
             `
           )}
         </ha-select>
@@ -90,7 +112,7 @@ export class HaPickThemeRow extends LitElement {
         this.hass.themes.default_dark_theme &&
         this.hass.themes.default_theme) ||
       this._supportsModeSelection(curTheme)
-        ? html` <div class="inputs">
+        ? html`<div class="inputs">
             <ha-formfield
               .label=${this.hass.localize(
                 "ui.panel.profile.themes.dark_mode.auto"
@@ -100,7 +122,7 @@ export class HaPickThemeRow extends LitElement {
                 @change=${this._handleDarkMode}
                 name="dark_mode"
                 value="auto"
-                .checked=${themeSettings?.dark === undefined}
+                .checked=${this._selectedTheme?.dark === undefined}
               ></ha-radio>
             </ha-formfield>
             <ha-formfield
@@ -112,7 +134,7 @@ export class HaPickThemeRow extends LitElement {
                 @change=${this._handleDarkMode}
                 name="dark_mode"
                 value="light"
-                .checked=${themeSettings?.dark === false}
+                .checked=${this._selectedTheme?.dark === false}
               >
               </ha-radio>
             </ha-formfield>
@@ -125,14 +147,14 @@ export class HaPickThemeRow extends LitElement {
                 @change=${this._handleDarkMode}
                 name="dark_mode"
                 value="dark"
-                .checked=${themeSettings?.dark === true}
+                .checked=${this._selectedTheme?.dark === true}
               >
               </ha-radio>
             </ha-formfield>
             ${curTheme === HOME_ASSISTANT_THEME
               ? html`<div class="color-pickers">
                   <ha-textfield
-                    .value=${themeSettings?.primaryColor ||
+                    .value=${this._selectedTheme?.primaryColor ||
                     DEFAULT_PRIMARY_COLOR}
                     type="color"
                     .label=${this.hass.localize(
@@ -142,7 +164,8 @@ export class HaPickThemeRow extends LitElement {
                     @change=${this._handleColorChange}
                   ></ha-textfield>
                   <ha-textfield
-                    .value=${themeSettings?.accentColor || DEFAULT_ACCENT_COLOR}
+                    .value=${this._selectedTheme?.accentColor ||
+                    DEFAULT_ACCENT_COLOR}
                     type="color"
                     .label=${this.hass.localize(
                       "ui.panel.profile.themes.accent_color"
@@ -150,19 +173,36 @@ export class HaPickThemeRow extends LitElement {
                     .name=${"accentColor"}
                     @change=${this._handleColorChange}
                   ></ha-textfield>
-                  ${themeSettings?.primaryColor || themeSettings?.accentColor
-                    ? html` <mwc-button @click=${this._resetColors}>
+                  ${this._selectedTheme?.primaryColor ||
+                  this._selectedTheme?.accentColor
+                    ? html`<ha-button @click=${this._resetColors}>
                         ${this.hass.localize("ui.panel.profile.themes.reset")}
-                      </mwc-button>`
-                    : ""}
+                      </ha-button>`
+                    : nothing}
                 </div>`
-              : ""}
+              : nothing}
           </div>`
-        : ""}
+        : nothing}
     `;
   }
 
   public willUpdate(changedProperties: PropertyValues) {
+    if (!this.hasUpdated) {
+      if (this.storageLocation === "browser") {
+        this._selectedTheme = this.hass.selectedTheme ?? undefined;
+      } else {
+        this._loading = true;
+        this._selectedTheme = undefined;
+        subscribeSelectedTheme(
+          this.hass,
+          (selectedTheme?: ThemeSettings | null) => {
+            this._selectedTheme = selectedTheme ?? undefined;
+            this._loading = false;
+          }
+        );
+      }
+    }
+
     const oldHass = changedProperties.get("hass") as undefined | HomeAssistant;
     const themesChanged =
       changedProperties.has("hass") &&
@@ -173,21 +213,36 @@ export class HaPickThemeRow extends LitElement {
     }
   }
 
-  private _handleColorChange(ev: CustomEvent) {
-    const target = ev.target as any;
+  private _shouldSaveHass() {
+    return (
+      this.storageLocation === "browser" ||
+      (this.storageLocation === "user" && !this.hass.browserThemeEnabled)
+    );
+  }
+
+  private _updateSelectedTheme(updatedTheme: Partial<ThemeSettings>) {
+    this._selectedTheme = {
+      ...this._selectedTheme,
+      ...updatedTheme,
+      theme: updatedTheme.theme ?? this._selectedTheme?.theme ?? "",
+    };
+
     fireEvent(this, "settheme", {
-      settings: { [target.name]: target.value },
+      settings: this._selectedTheme,
       storageLocation: this.storageLocation,
+      saveHass: this._shouldSaveHass(),
     });
   }
 
+  private _handleColorChange(ev: CustomEvent) {
+    const target = ev.target as any;
+    this._updateSelectedTheme({ [target.name]: target.value });
+  }
+
   private _resetColors() {
-    fireEvent(this, "settheme", {
-      settings: {
-        primaryColor: undefined,
-        accentColor: undefined,
-      },
-      storageLocation: this.storageLocation,
+    this._updateSelectedTheme({
+      primaryColor: undefined,
+      accentColor: undefined,
     });
   }
 
@@ -208,38 +263,29 @@ export class HaPickThemeRow extends LitElement {
         dark = true;
         break;
     }
-    fireEvent(this, "settheme", {
-      settings: { dark },
-      storageLocation: this.storageLocation,
-    });
+    this._updateSelectedTheme({ dark });
   }
 
   private _handleThemeSelection(ev) {
     const theme = ev.target.value;
-    if (theme === this.hass.selectedTheme?.theme) {
+    if (theme === this._selectedTheme?.theme) {
       return;
     }
 
     if (theme === USE_DEFAULT_THEME) {
       if (this.hass.selectedTheme?.theme) {
-        fireEvent(this, "settheme", {
-          settings: {
-            theme: "",
-            primaryColor: undefined,
-            accentColor: undefined,
-          },
-          storageLocation: this.storageLocation,
+        this._updateSelectedTheme({
+          theme: "",
+          primaryColor: undefined,
+          accentColor: undefined,
         });
       }
       return;
     }
-    fireEvent(this, "settheme", {
-      settings: {
-        theme,
-        primaryColor: undefined,
-        accentColor: undefined,
-      },
-      storageLocation: this.storageLocation,
+    this._updateSelectedTheme({
+      theme,
+      primaryColor: undefined,
+      accentColor: undefined,
     });
   }
 
@@ -267,6 +313,12 @@ export class HaPickThemeRow extends LitElement {
       min-width: 75px;
       flex-grow: 1;
       margin: 0 4px;
+    }
+    .device-info {
+      color: var(--warning-color);
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
   `;
 }

--- a/src/panels/profile/ha-profile-section-general.ts
+++ b/src/panels/profile/ha-profile-section-general.ts
@@ -1,4 +1,3 @@
-import { mdiAlertCircleOutline } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
@@ -8,7 +7,6 @@ import "../../components/ha-card";
 import "../../components/ha-button";
 import "../../components/ha-expansion-panel";
 import "../../components/ha-switch";
-import "../../components/ha-svg-icon";
 import "../../layouts/hass-tabs-subpage";
 import { profileSections } from "./ha-panel-profile";
 import { isExternal } from "../../data/external";
@@ -135,26 +133,12 @@ class HaProfileSectionGeneral extends LitElement {
               .narrow=${this.narrow}
               .hass=${this.hass}
             ></ha-pick-first-weekday-row>
-            ${this.hass.browserThemeEnabled || this._browserThemeActivated
-              ? html`
-                  <ha-settings-row .narrow=${this.narrow}>
-                    <span slot="heading">
-                      ${this.hass.localize("ui.panel.profile.themes.header")}
-                    </span>
-                    <span class="theme-warning" slot="description">
-                      <ha-svg-icon .path=${mdiAlertCircleOutline}></ha-svg-icon>
-                      ${this.hass.localize(
-                        "ui.panel.profile.themes.device.user_theme_info"
-                      )}
-                    </span>
-                  </ha-settings-row>
-                `
-              : html`<ha-pick-theme-row
-                  .narrow=${this.narrow}
-                  .hass=${this.hass}
-                  this._browserThemeActivated}
-                  .storageLocation=${"user"}
-                ></ha-pick-theme-row>`}
+            <ha-pick-theme-row
+              .narrow=${this.narrow}
+              .hass=${this.hass}
+              this._browserThemeActivated}
+              .storageLocation=${"user"}
+            ></ha-pick-theme-row>
             ${this.hass.user!.is_admin
               ? html`
                   <ha-advanced-mode-row
@@ -346,12 +330,6 @@ class HaProfileSectionGeneral extends LitElement {
 
         ha-expansion-panel {
           margin: 0 8px 8px;
-        }
-        .theme-warning {
-          color: var(--warning-color);
-          display: flex;
-          align-items: center;
-          gap: 8px;
         }
         .device-theme {
           display: block;

--- a/src/panels/profile/ha-profile-section-general.ts
+++ b/src/panels/profile/ha-profile-section-general.ts
@@ -12,12 +12,11 @@ import "../../components/ha-svg-icon";
 import "../../layouts/hass-tabs-subpage";
 import { profileSections } from "./ha-panel-profile";
 import { isExternal } from "../../data/external";
-import { SELECTED_THEME_KEY } from "../../data/ws-themes";
 import type { CoreFrontendUserData } from "../../data/frontend";
 import { getOptimisticFrontendUserDataCollection } from "../../data/frontend";
 import { showConfirmationDialog } from "../../dialogs/generic/show-dialog-box";
 import { haStyle } from "../../resources/styles";
-import type { HomeAssistant, Route, ThemeSettings } from "../../types";
+import type { HomeAssistant, Route } from "../../types";
 import "./ha-advanced-mode-row";
 import "./ha-enable-shortcuts-row";
 import "./ha-force-narrow-row";
@@ -32,7 +31,6 @@ import "./ha-pick-time-zone-row";
 import "./ha-push-notifications-row";
 import "./ha-set-suspend-row";
 import "./ha-set-vibrate-row";
-import { storage } from "../../common/decorators/storage";
 import type { HaSwitch } from "../../components/ha-switch";
 
 @customElement("ha-profile-section-general")
@@ -44,13 +42,6 @@ class HaProfileSectionGeneral extends LitElement {
   @state() private _coreUserData?: CoreFrontendUserData | null;
 
   @property({ attribute: false }) public route!: Route;
-
-  @storage({
-    key: SELECTED_THEME_KEY,
-    state: true,
-    subscribe: true,
-  })
-  private _browserThemeSettings?: ThemeSettings;
 
   @state() private _browserThemeActivated = false;
 
@@ -144,7 +135,7 @@ class HaProfileSectionGeneral extends LitElement {
               .narrow=${this.narrow}
               .hass=${this.hass}
             ></ha-pick-first-weekday-row>
-            ${this._browserThemeSettings || this._browserThemeActivated
+            ${this.hass.browserThemeEnabled || this._browserThemeActivated
               ? html`
                   <ha-settings-row .narrow=${this.narrow}>
                     <span slot="heading">
@@ -198,12 +189,12 @@ class HaProfileSectionGeneral extends LitElement {
                 )}
               </span>
               <ha-switch
-                .checked=${!!this._browserThemeSettings ||
+                .checked=${this.hass.browserThemeEnabled ||
                 this._browserThemeActivated}
                 @change=${this._toggleBrowserTheme}
               ></ha-switch>
             </ha-settings-row>
-            ${this._browserThemeSettings || this._browserThemeActivated
+            ${this.hass.browserThemeEnabled || this._browserThemeActivated
               ? html`
                   <ha-expansion-panel
                     outlined
@@ -298,7 +289,7 @@ class HaProfileSectionGeneral extends LitElement {
     const enabled = switchElement.checked;
 
     if (!enabled) {
-      if (!this._browserThemeSettings && this._browserThemeActivated) {
+      if (!this.hass.browserThemeEnabled && this._browserThemeActivated) {
         // no changed have made, disable without confirmation
         this._browserThemeActivated = false;
       } else {
@@ -315,7 +306,6 @@ class HaProfileSectionGeneral extends LitElement {
 
         if (confirm) {
           this._browserThemeActivated = false;
-          this._browserThemeSettings = undefined;
           fireEvent(this, "resetBrowserTheme");
         } else {
           // revert switch

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -51,6 +51,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         };
         this._updateHass({
           selectedTheme,
+          browserThemeEnabled: ev.detail.storageLocation === "browser",
         });
         this._applyTheme(mql.matches);
 
@@ -67,6 +68,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         const selectedTheme = await fetchSelectedTheme(this.hass!);
         this._updateHass({
           selectedTheme,
+          browserThemeEnabled: false,
         });
         this._applyTheme(mql.matches);
       });
@@ -108,7 +110,10 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
             selectedTheme
           ) {
             this._themeApplied = true;
-            this._updateHass({ selectedTheme });
+            this._updateHass({
+              selectedTheme,
+              browserThemeEnabled: false,
+            });
             this._applyTheme(mql.matches);
           }
         }

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -155,7 +155,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
           },
           {
             duration: 500,
-            easing: "ease-in-out",
+            easing: "linear(0, 0.1, 1)",
             pseudoElement: "::view-transition-new(root)",
           }
         );

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -17,8 +17,9 @@ import type { HassBaseEl } from "./hass-base-mixin";
 export type StorageLocation = "user" | "browser";
 
 interface SetThemeSettings {
-  settings: Partial<HomeAssistant["selectedTheme"]>;
+  settings: ThemeSettings;
   storageLocation: StorageLocation;
+  saveHass: boolean;
 }
 
 declare global {
@@ -45,21 +46,21 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
     protected firstUpdated(changedProps) {
       super.firstUpdated(changedProps);
       this.addEventListener("settheme", (ev) => {
-        const selectedTheme = {
-          ...this.hass!.selectedTheme!,
-          ...ev.detail.settings,
-        };
-        this._updateHass({
-          selectedTheme,
-          browserThemeEnabled: ev.detail.storageLocation === "browser",
-        });
-        this._applyTheme(mql.matches);
+        if (ev.detail.saveHass) {
+          this._updateHass({
+            selectedTheme: ev.detail.settings,
+            browserThemeEnabled: ev.detail.storageLocation === "browser",
+          });
+          this._applyTheme(mql.matches);
+        }
 
         if (ev.detail.storageLocation === "browser") {
           storeState(this.hass!);
         } else {
-          clearStateKey(SELECTED_THEME_KEY);
-          saveSelectedTheme(this.hass!, selectedTheme);
+          if (ev.detail.saveHass) {
+            clearStateKey(SELECTED_THEME_KEY);
+          }
+          saveSelectedTheme(this.hass!, ev.detail.settings);
         }
       });
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7583,7 +7583,7 @@
             "description": "Overwrite user theme with custom device settings",
             "delete_header": "Delete device theme",
             "delete_description": "Are you sure you want to delete the device specific theme?",
-            "user_theme_info": "Device theme is active. Delete it to edit the user theme."
+            "user_theme_info": "Device theme is active. You won't see changes on user theme settings."
           }
         },
         "dashboard": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7575,7 +7575,16 @@
           "primary_color": "Primary color",
           "accent_color": "Accent color",
           "reset": "Reset",
-          "use_default": "Use default theme"
+          "use_default": "Use default theme",
+          "device": {
+            "browser_header": "Browser theme",
+            "mobile_app_header": "Mobile app theme",
+            "custom_theme": "Custom theme",
+            "description": "Overwrite user theme with custom device settings",
+            "delete_header": "Delete device theme",
+            "delete_description": "Are you sure you want to delete the device specific theme?",
+            "user_theme_info": "Device theme is active. Delete it to edit the user theme."
+          }
         },
         "dashboard": {
           "header": "Dashboard",

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,7 @@ export interface HomeAssistant {
   config: HassConfig;
   themes: Themes;
   selectedTheme: ThemeSettings | null;
+  browserThemeEnabled?: boolean;
   panels: Panels;
   panelUrl: string;
   // i18n

--- a/src/util/ha-pref-storage.ts
+++ b/src/util/ha-pref-storage.ts
@@ -11,6 +11,8 @@ const STORED_STATE = [
   "defaultPanel",
 ];
 
+const CLEARABLE_STATE = ["selectedTheme"];
+
 export function storeState(hass: HomeAssistant) {
   try {
     STORED_STATE.forEach((key) => {
@@ -54,4 +56,10 @@ export function getState() {
 
 export function clearState() {
   window.localStorage.clear();
+}
+
+export function clearStateKey(key: string) {
+  if (CLEARABLE_STATE.includes(key)) {
+    window.localStorage.removeItem(key);
+  }
 }

--- a/src/util/ha-pref-storage.ts
+++ b/src/util/ha-pref-storage.ts
@@ -1,8 +1,9 @@
+import { SELECTED_THEME_KEY } from "../data/ws-themes";
 import type { HomeAssistant } from "../types";
 
 const STORED_STATE = [
   "dockedSidebar",
-  "selectedTheme",
+  SELECTED_THEME_KEY,
   "selectedLanguage",
   "vibrate",
   "debugConnection",
@@ -11,11 +12,17 @@ const STORED_STATE = [
   "defaultPanel",
 ];
 
-const CLEARABLE_STATE = ["selectedTheme"];
+const CLEARABLE_STATE = [SELECTED_THEME_KEY];
 
 export function storeState(hass: HomeAssistant) {
   try {
-    STORED_STATE.forEach((key) => {
+    const states = [...STORED_STATE];
+
+    if (!hass.browserThemeEnabled) {
+      states.splice(states.indexOf(SELECTED_THEME_KEY), 1);
+    }
+
+    states.forEach((key) => {
       const value = hass[key];
       window.localStorage.setItem(
         key,
@@ -34,15 +41,18 @@ export function storeState(hass: HomeAssistant) {
 }
 
 export function getState() {
-  const state = {};
+  const state: Partial<HomeAssistant> = {};
 
   STORED_STATE.forEach((key) => {
     const storageItem = window.localStorage.getItem(key);
     if (storageItem !== null) {
       let value = JSON.parse(storageItem);
       // selectedTheme went from string to object on 20200718
-      if (key === "selectedTheme" && typeof value === "string") {
-        value = { theme: value };
+      if (key === SELECTED_THEME_KEY) {
+        if (typeof value === "string") {
+          value = { theme: value };
+        }
+        state.browserThemeEnabled = true;
       }
       // dockedSidebar went from boolean to enum on 20190720
       if (key === "dockedSidebar" && typeof value === "boolean") {


### PR DESCRIPTION
## Proposed change
- Backwards compatible theme by user setting in Profile 
- Migrated depricated `mql.addListener` to `mql.addEventListener`
- add switch theme animation for supported browsers (not Firefox)

![image](https://github.com/user-attachments/assets/14c01d58-87f8-412c-9564-4d1e518d4e5a)

![image](https://github.com/user-attachments/assets/3daa97af-b087-467b-bb1b-4a3bb7ab88ac)

https://github.com/user-attachments/assets/1731c868-e4d2-48cc-977d-d402fa63806d




Known bugs:
- if `storeState` is called from any change it will set the browser theme :see_no_evil: 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
