### PR TITLE
Show light's color temperature state when selected in more info

### DIFF
--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -74,6 +74,15 @@ class MoreInfoLight extends LitElement {
   }
 
   private get _stateOverride() {
+    if (
+      this._mainControl === "color_temp" &&
+      this.stateObj?.attributes.color_temp_kelvin
+    ) {
+      return this.hass.formatEntityAttributeValue(
+        this.stateObj!,
+        "color_temp_kelvin"
+      );
+    }
     if (this.stateObj?.attributes.brightness) {
       return this.hass.formatEntityAttributeValue(this.stateObj!, "brightness");
     }


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When viewing a light's color temperature in the more info view it would only display brightness percentage. To see the color temperature you would have to move the slider which then changes the color temperate. This change simply displays the color temperature value in kelvin when the color temperature view is selected.

These screenshots show the before and after of the change.

<img width="584" alt="Screenshot 2025-02-15 at 8 49 58 AM" src="https://github.com/user-attachments/assets/9eae7024-b218-45fc-9dbb-2e8e97143c59" />

<img width="586" alt="Screenshot 2025-02-15 at 8 50 11 AM" src="https://github.com/user-attachments/assets/675b0341-0c9c-42a9-91de-bd327cb6da52" />

I have not added any new tests, but if you would like me to just let me know, thanks!

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

As long as you have a light configured that supports color temperate it should be easy to test.

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
