### PR TITLE
Fix error handling/flickering in markdown card

### DIFF
--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -107,7 +107,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
       this._tryConnect();
     }
     const shouldBeHidden =
-      this._templateResult &&
+      !!this._templateResult &&
       this._config.show_empty === false &&
       this._templateResult.result.length === 0;
     if (shouldBeHidden !== this.hidden) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
When _templateResult is undefined, it makes `shouldBeHidden` also undefined, and that means on every updated it never matches this.hidden and we're firing a visibility changed event on every update cycle.

If a card had markdown error, this would manifest as it flickering in and out of existence on a dashboard, sometimes multiple times in a second, between being completely hidden, and showing an empty hui-card, and getting into an infinite loop of connectedCallback/disconnectedCallback.

I think this would also manifest as template errors not being shown in the card editor, as that would show the same flicking behavior instead of showing the ha-alert with the error. I think what was happened was we are disconnecting/unsubscribing from the template as soon as we initiated the subscription, so we never really got a chance to get the result, but it's difficult to pin down exactly.

This change seems to more match the original intention and I observe better behavior as a result.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
