### PR TITLE
Fix theme2hex with custom theme colors

### DIFF
--- a/src/common/color/convert-color.ts
+++ b/src/common/color/convert-color.ts
@@ -136,11 +136,18 @@ export function theme2hex(themeColor: string): string {
   }
 
   const rgbFromColorName = colors[themeColor];
-  if (!rgbFromColorName) {
-    // We have a named color, and there's nothing in the table,
-    // so nothing further we can do with it.
-    // Compare/border/background color will all be the same.
-    return themeColor;
+  if (rgbFromColorName) {
+    return rgb2hex(rgbFromColorName);
   }
-  return rgb2hex(rgbFromColorName);
+
+  const rgbMatch = themeColor.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (rgbMatch) {
+    const [, r, g, b] = rgbMatch.map(Number);
+    return rgb2hex([r, g, b]);
+  }
+
+  // We have a named color, and there's nothing in the table,
+  // so nothing further we can do with it.
+  // Compare/border/background color will all be the same.
+  return themeColor;
 }

--- a/test/common/color/convert-color.test.ts
+++ b/test/common/color/convert-color.test.ts
@@ -51,4 +51,16 @@ describe("Color Conversion Tests", () => {
     expect(theme2hex("#ff0000")).toBe("#ff0000");
     expect(theme2hex("unicorn")).toBe("unicorn");
   });
+
+  it("should convert rgb theme color to hex", () => {
+    expect(theme2hex("rgb( 255, 0, 0)")).toBe("#ff0000");
+    expect(theme2hex("rgb(0,255, 0)")).toBe("#00ff00");
+    expect(theme2hex("rgb(0, 0,255 )")).toBe("#0000ff");
+  });
+
+  it("should convert rgba theme color to hex by ignoring alpha", () => {
+    expect(theme2hex("rgba( 255, 0, 0, 0.5)")).toBe("#ff0000");
+    expect(theme2hex("rgba(0,255, 0, 0.3)")).toBe("#00ff00");
+    expect(theme2hex("rgba(0, 0,255 , 0.7)")).toBe("#0000ff");
+  });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
I encountered an issue where `theme2hex` was not working correctly with custom theme colors when `rgba` or `rgb` was used in the CSS config instead of hex.

For example with https://github.com/Nezz/homeassistant-visionos-theme this results in broken color tags because the "untracked consumption" ends up being `rgba(208, 208, 208, 0.5)7F` instead of `#D0D0D07F` when concatenation happens here:
https://github.com/home-assistant/frontend/blob/3ee3cfa6cb471cbb0a3874b56b1bac00ecf74805/src/panels/lovelace/cards/energy/common/color.ts#L43-L49

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Example theme configuration:
```yaml
state-unavailable-color: rgba(208, 208, 208, 0.5)
```
or

```yaml
state-unavailable-color: rgb(208, 208, 208)
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/Nezz/homeassistant-visionos-theme/issues/10
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
