### PR TITLE
Z-WaveJS: stop inclusion subscription while dialog is open

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -116,10 +116,8 @@ class DialogZWaveJSAddNode extends LitElement {
     if (params.dsk) {
       this._status = "validate_dsk_enter_pin";
       this._dsk = params.dsk;
-      this._startInclusion(undefined, params.dsk);
-    } else {
-      this._startInclusion();
     }
+    this._startInclusion();
   }
 
   @query("#pin-input") private _pinInput?: HaTextField;

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -78,7 +78,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
 
   private _dialogOpen = false;
 
-  private _s2InclusionUnsubscribe?: UnsubscribeFunc;
+  private _s2InclusionUnsubscribe?: Promise<UnsubscribeFunc>;
 
   protected async firstUpdated() {
     if (this.hass) {
@@ -611,7 +611,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
     if (!this._dialogOpen) {
       // Unsubscribe from S2 inclusion before opening dialog
       if (this._s2InclusionUnsubscribe) {
-        this._s2InclusionUnsubscribe();
+        this._s2InclusionUnsubscribe.then((unsubscribe) => unsubscribe());
         this._s2InclusionUnsubscribe = undefined;
       }
 
@@ -631,8 +631,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
     this._subscribeS2Inclusion();
   };
 
-  private async _subscribeS2Inclusion() {
-    this._s2InclusionUnsubscribe = await subscribeS2Inclusion(
+  private _subscribeS2Inclusion() {
+    this._s2InclusionUnsubscribe = subscribeS2Inclusion(
       this.hass,
       this.configEntryId,
       (message) => {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -78,6 +78,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
 
   private _dialogOpen = false;
 
+  private _s2InclusionUnsubscribe?: UnsubscribeFunc;
+
   protected async firstUpdated() {
     if (this.hass) {
       await this._fetchData();
@@ -105,19 +107,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
           this._statistics = message;
         }
       ),
-      subscribeS2Inclusion(this.hass, this.configEntryId, (message) => {
-        if (!this._dialogOpen) {
-          showZWaveJSAddNodeDialog(this, {
-            entry_id: this.configEntryId,
-            dsk: message.dsk,
-            onStop: () => {
-              setTimeout(() => this._fetchData(), 100);
-              this._dialogOpen = false;
-            },
-          });
-          this._dialogOpen = true;
-        }
-      }),
+      this._subscribeS2Inclusion(),
     ];
   }
 
@@ -578,17 +568,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
   }
 
   private async _addNodeClicked() {
-    if (!this._dialogOpen) {
-      showZWaveJSAddNodeDialog(this, {
-        entry_id: this.configEntryId!,
-        // refresh the data after the dialog is closed. add a small delay for the inclusion state to update
-        onStop: () => {
-          setTimeout(() => this._fetchData(), 100);
-          this._dialogOpen = false;
-        },
-      });
-      this._dialogOpen = true;
-    }
+    this._openInclusionDialog();
   }
 
   private async _removeNodeClicked() {
@@ -625,6 +605,41 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
       (entry) => entry.entry_id === this.configEntryId
     );
     showOptionsFlowDialog(this, configEntry!);
+  }
+
+  private _openInclusionDialog(dsk?: string) {
+    if (!this._dialogOpen) {
+      // Unsubscribe from S2 inclusion before opening dialog
+      if (this._s2InclusionUnsubscribe) {
+        this._s2InclusionUnsubscribe();
+        this._s2InclusionUnsubscribe = undefined;
+      }
+
+      showZWaveJSAddNodeDialog(this, {
+        entry_id: this.configEntryId!,
+        dsk,
+        onStop: this._handleInclusionDialogClosed,
+      });
+      this._dialogOpen = true;
+    }
+  }
+
+  private _handleInclusionDialogClosed = () => {
+    // refresh the data after the dialog is closed. add a small delay for the inclusion state to update
+    setTimeout(() => this._fetchData(), 100);
+    this._dialogOpen = false;
+    this._subscribeS2Inclusion();
+  };
+
+  private async _subscribeS2Inclusion() {
+    this._s2InclusionUnsubscribe = await subscribeS2Inclusion(
+      this.hass,
+      this.configEntryId,
+      (message) => {
+        this._openInclusionDialog(message.dsk);
+      }
+    );
+    return this._s2InclusionUnsubscribe;
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Stop the page subscription when the inclusion dialog is open as the dialog is handling everything at that point. Resub after the dialog is closed.
Also don't pass the DSK to core when there is a controller initiated inclusion as that doesn't include the pin yet.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
