### PR TITLE
Improve margin for inline tile card feature

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -416,13 +416,10 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       align-items: center;
       padding: 10px;
       flex: 1;
+      min-width: 0;
       box-sizing: border-box;
       pointer-events: none;
       gap: 10px;
-    }
-
-    .container.horizontal .content {
-      width: 50%;
     }
 
     .vertical {
@@ -458,9 +455,10 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       padding: 0 12px 12px 12px;
     }
     .container.horizontal hui-card-features {
-      width: 50%;
+      width: calc(50% - var(--column-gap, 0px) / 2 - 12px);
+      flex: none;
       --feature-height: 36px;
-      padding: 10px;
+      padding: 0 12px;
       padding-inline-start: 0;
     }
 


### PR DESCRIPTION
## Proposed change

Improve tile card feature size in inline mode so inline and bottom features are aligned in the grid.

![CleanShot 2025-02-19 at 14 36 37](https://github.com/user-attachments/assets/649148cd-bf30-44d1-98cf-78971371a80f)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
