### PR TITLE
Remove toggles from ha-icon-button

### DIFF
--- a/src/components/ha-copy-textfield.ts
+++ b/src/components/ha-copy-textfield.ts
@@ -40,7 +40,6 @@ export class HaCopyTextfield extends LitElement {
           ${this.maskedValue
             ? html`<ha-icon-button
                 class="toggle-unmasked"
-                toggles
                 .label=${this.hass.localize(
                   `ui.common.${this._showMasked ? "show" : "hide"}`
                 )}

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -80,7 +80,6 @@ export class HaFormString extends LitElement implements HaFormElement {
     if (!this.isPassword) return nothing;
     return html`
       <ha-icon-button
-        toggles
         .label=${this.localize?.(
           `${this.localizeBaseKey}.${
             this.unmaskedPassword ? "hide_password" : "show_password"

--- a/src/components/ha-password-field.ts
+++ b/src/components/ha-password-field.ts
@@ -132,7 +132,6 @@ export class HaPasswordField extends LitElement {
         @change=${this._handleChangeEvent}
       ></ha-textfield>
       <ha-icon-button
-        toggles
         .label=${this.hass?.localize(
           this._unmaskedPassword
             ? "ui.components.selectors.text.hide_password"

--- a/src/components/ha-selector/ha-selector-text.ts
+++ b/src/components/ha-selector/ha-selector-text.ts
@@ -95,7 +95,6 @@ export class HaTextSelector extends LitElement {
       ></ha-textfield>
       ${this.selector.text?.type === "password"
         ? html`<ha-icon-button
-            toggles
             .label=${this.hass?.localize(
               this._unmaskedPassword
                 ? "ui.components.selectors.text.hide_password"

--- a/src/panels/config/network/ha-config-url-form.ts
+++ b/src/panels/config/network/ha-config-url-form.ts
@@ -153,7 +153,6 @@ class ConfigUrlForm extends LitElement {
                 ? html`
                     <ha-icon-button
                       class="toggle-unmasked-url"
-                      toggles
                       .label=${this.hass.localize(
                         `ui.panel.config.common.${this._unmaskedExternalUrl ? "hide" : "show"}_url`
                       )}
@@ -254,7 +253,6 @@ class ConfigUrlForm extends LitElement {
                 ? html`
                     <ha-icon-button
                       class="toggle-unmasked-url"
-                      toggles
                       .label=${this.hass.localize(
                         `ui.panel.config.common.${this._unmaskedInternalUrl ? "hide" : "show"}_url`
                       )}


### PR DESCRIPTION
## Proposed change
- Remove `toggles` property at `ha-icon-button` because it has no functionality


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #24301
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
