### PR TITLE
Support `limits` in sensor card editor

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
@@ -165,11 +165,11 @@ export class HuiSensorCardEditor
         );
       case "min":
         return this.hass!.localize(
-          "ui.dialogs.helper_settings.input_number.min"
+          "ui.panel.lovelace.editor.card.sensor.limit_min"
         );
       case "max":
         return this.hass!.localize(
-          "ui.dialogs.helper_settings.input_number.max"
+          "ui.panel.lovelace.editor.card.sensor.limit_max"
         );
       default:
         return this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
@@ -32,6 +32,12 @@ const cardConfigStruct = assign(
     detail: optional(number()),
     theme: optional(string()),
     hours_to_show: optional(number()),
+    limits: optional(
+      object({
+        min: optional(number()),
+        max: optional(number()),
+      })
+    ),
   })
 );
 
@@ -80,6 +86,20 @@ const SCHEMA = [
         name: "hours_to_show",
         default: DEFAULT_HOURS_TO_SHOW,
         selector: { number: { min: 1, mode: "box" } },
+      },
+    ],
+  },
+  {
+    type: "grid",
+    name: "limits",
+    schema: [
+      {
+        name: "min",
+        selector: { number: { mode: "box" } },
+      },
+      {
+        name: "max",
+        selector: { number: { mode: "box" } },
       },
     ],
   },
@@ -142,6 +162,14 @@ export class HuiSensorCardEditor
       case "graph":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.card.sensor.graph_type"
+        );
+      case "min":
+        return this.hass!.localize(
+          "ui.dialogs.helper_settings.input_number.min"
+        );
+      case "max":
+        return this.hass!.localize(
+          "ui.dialogs.helper_settings.input_number.max"
         );
       default:
         return this.hass!.localize(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7102,7 +7102,9 @@
               "name": "Sensor",
               "show_more_detail": "Show more detail",
               "graph_type": "Graph type",
-              "description": "The Sensor card gives you a quick overview of your sensors state with an optional graph to visualize change over time."
+              "description": "The Sensor card gives you a quick overview of your sensors state with an optional graph to visualize change over time.",
+              "limit_min": "Minimum value",
+              "limit_max": "Maximum value"
             },
             "todo-list": {
               "name": "To-do list",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR adds support for editing the `limits.min`/`limits.max` YAML values of the Sensor card in the UI.
See the documentation here: https://www.home-assistant.io/dashboards/sensor#limits

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/611fae65-d94f-46fd-a89b-f5ea32ba5d9e) | ![image](https://github.com/user-attachments/assets/2d6008d4-374a-4f25-9c28-6896fa828e01) |


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
graph: line
type: sensor
entity: sensor.bad_waschmaschine_surfou_smart_plug_leistung
detail: 2
name: Leistung
unit: W
hours_to_show: 6
limits:
  min: 100
grid_options:
  columns: full
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- ~This PR fixes or closes issue: fixes #~
- ~This PR is related to issue or discussion:~
- ~Link to documentation pull request:~

No open issues/PRs I could find.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] ~Documentation added/updated for [www.home-assistant.io][docs-repository]~

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
