### PR TITLE
Light hue slider card feature

### DIFF
--- a/src/panels/lovelace/card-features/hui-light-color-hue-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-color-hue-card-feature.ts
@@ -1,0 +1,131 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import memoizeOne from "memoize-one";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import { stateActive } from "../../../common/entity/state_active";
+import "../../../components/ha-control-slider";
+import { UNAVAILABLE } from "../../../data/entity";
+import { LightColorMode, lightSupportsColorMode } from "../../../data/light";
+import type { HomeAssistant } from "../../../types";
+import type { LovelaceCardFeature } from "../types";
+import { cardFeatureStyles } from "./common/card-feature-styles";
+import type { LightColorHueCardFeatureConfig } from "./types";
+import { hsv2rgb, rgb2hex } from "../../../common/color/convert-color";
+
+const generateColorHueGradient = () => {
+  const count = 10;
+  const gradient: [number, string][] = [];
+  const percentageStep = 1 / count;
+
+  for (let i = 0; i < count + 1; i++) {
+    const value = i * percentageStep * 360;
+    const hex = rgb2hex(hsv2rgb([value, 1, 255]));
+    gradient.push([percentageStep * i, hex]);
+  }
+
+  return gradient
+    .map(([stop, color]) => `${color} ${(stop as number) * 100}%`)
+    .join(", ");
+};
+
+export const supportsLightColorHueCardFeature = (stateObj: HassEntity) => {
+  const domain = computeDomain(stateObj.entity_id);
+  return (
+    domain === "light" && lightSupportsColorMode(stateObj, LightColorMode.HS)
+  );
+};
+
+@customElement("hui-light-color-hue-card-feature")
+class HuiLightColorHueCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state() private _config?: LightColorHueCardFeatureConfig;
+
+  static getStubConfig(): LightColorHueCardFeatureConfig {
+    return {
+      type: "light-color-hue",
+    };
+  }
+
+  public setConfig(config: LightColorHueCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render() {
+    if (
+      !this._config ||
+      !this.hass ||
+      !this.stateObj ||
+      !supportsLightColorHueCardFeature(this.stateObj)
+    ) {
+      return nothing;
+    }
+
+    const position =
+      this.stateObj.attributes.hs_color != null
+        ? this.stateObj.attributes.hs_color[0]
+        : undefined;
+
+    const gradient = this._generateHueGradient();
+
+    return html`
+      <ha-control-slider
+        .value=${position}
+        mode="cursor"
+        .showHandle=${stateActive(this.stateObj)}
+        .disabled=${this.stateObj!.state === UNAVAILABLE}
+        @value-changed=${this._valueChanged}
+        .label=${this.hass.localize("ui.card.light.color_hue")}
+        min="0"
+        max="360"
+        style=${styleMap({
+          "--gradient": gradient,
+        })}
+        .locale=${this.hass.locale}
+      ></ha-control-slider>
+    `;
+  }
+
+  private _generateHueGradient = memoizeOne(() => generateColorHueGradient());
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const value = ev.detail.value;
+
+    this.hass!.callService("light", "turn_on", {
+      entity_id: this.stateObj!.entity_id,
+      hs_color: [value, 100],
+    });
+  }
+
+  static get styles() {
+    return [
+      cardFeatureStyles,
+      css`
+        ha-control-slider {
+          --control-slider-background: -webkit-linear-gradient(
+            left,
+            var(--gradient)
+          );
+          --control-slider-background-opacity: 1;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-light-color-hue-card-feature": HuiLightColorHueCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -26,6 +26,10 @@ export interface LightColorTempCardFeatureConfig {
   type: "light-color-temp";
 }
 
+export interface LightColorHueCardFeatureConfig {
+  type: "light-color-hue";
+}
+
 export interface LockCommandsCardFeatureConfig {
   type: "lock-commands";
 }
@@ -167,6 +171,7 @@ export type LovelaceCardFeatureConfig =
   | LawnMowerCommandsCardFeatureConfig
   | LightBrightnessCardFeatureConfig
   | LightColorTempCardFeatureConfig
+  | LightColorHueCardFeatureConfig
   | LockCommandsCardFeatureConfig
   | LockOpenDoorCardFeatureConfig
   | MediaPlayerVolumeSliderCardFeatureConfig

--- a/src/panels/lovelace/create-element/create-card-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-card-feature-element.ts
@@ -15,6 +15,7 @@ import "../card-features/hui-humidifier-toggle-card-feature";
 import "../card-features/hui-lawn-mower-commands-card-feature";
 import "../card-features/hui-light-brightness-card-feature";
 import "../card-features/hui-light-color-temp-card-feature";
+import "../card-features/hui-light-color-hue-card-feature";
 import "../card-features/hui-lock-commands-card-feature";
 import "../card-features/hui-lock-open-door-card-feature";
 import "../card-features/hui-media-player-volume-slider-card-feature";
@@ -51,6 +52,7 @@ const TYPES = new Set<LovelaceCardFeatureConfig["type"]>([
   "lawn-mower-commands",
   "light-brightness",
   "light-color-temp",
+  "light-color-hue",
   "lock-commands",
   "lock-open-door",
   "media-player-volume-slider",

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -35,6 +35,7 @@ import { supportsHumidifierToggleCardFeature } from "../../card-features/hui-hum
 import { supportsLawnMowerCommandCardFeature } from "../../card-features/hui-lawn-mower-commands-card-feature";
 import { supportsLightBrightnessCardFeature } from "../../card-features/hui-light-brightness-card-feature";
 import { supportsLightColorTempCardFeature } from "../../card-features/hui-light-color-temp-card-feature";
+import { supportsLightColorHueCardFeature } from "../../card-features/hui-light-color-hue-card-feature";
 import { supportsLockCommandsCardFeature } from "../../card-features/hui-lock-commands-card-feature";
 import { supportsLockOpenDoorCardFeature } from "../../card-features/hui-lock-open-door-card-feature";
 import { supportsMediaPlayerVolumeSliderCardFeature } from "../../card-features/hui-media-player-volume-slider-card-feature";
@@ -70,6 +71,7 @@ const UI_FEATURE_TYPES = [
   "lawn-mower-commands",
   "light-brightness",
   "light-color-temp",
+  "light-color-hue",
   "lock-commands",
   "lock-open-door",
   "media-player-volume-slider",
@@ -124,6 +126,7 @@ const SUPPORTS_FEATURE_TYPES: Record<
   "lawn-mower-commands": supportsLawnMowerCommandCardFeature,
   "light-brightness": supportsLightBrightnessCardFeature,
   "light-color-temp": supportsLightColorTempCardFeature,
+  "light-color-hue": supportsLightColorHueCardFeature,
   "lock-commands": supportsLockCommandsCardFeature,
   "lock-open-door": supportsLockOpenDoorCardFeature,
   "media-player-volume-slider": supportsMediaPlayerVolumeSliderCardFeature,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -182,6 +182,7 @@
       "light": {
         "brightness": "Brightness",
         "color_temperature": "Color temperature",
+        "color_hue": "Color hue",
         "white_value": "White brightness",
         "color_brightness": "Color brightness",
         "cold_white_value": "Cold white brightness",
@@ -7249,6 +7250,9 @@
               },
               "light-color-temp": {
                 "label": "Light color temperature"
+              },
+              "light-color-hue": {
+                "label": "Light color hue"
               },
               "lock-commands": {
                 "label": "Lock commands"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Color slider feature for hue/sat lights. (A copy/paste of the color temp implementation). 

![image](https://github.com/user-attachments/assets/dd1cfbeb-3d4b-4229-af62-c866b5cd6540)

Design caveats:

 - Only supports lights that support HS mode. It could probably more broadly support other color types (xy/rgbw*), but just keeping it simple to start. (I suspect this is probably too restrictive for production, so I can improve it in this PR if desired)
 
 - Moving the slider always sets saturation to max value. Just guessing that most people who play with color bulbs want the most saturated color. If we want to enhance further, we can add a saturation slider as well, and maybe an option to this feature if it should attempt to hold the current saturation, or always just use max saturation. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://github.com/home-assistant/frontend/discussions/22423
https://github.com/home-assistant/frontend/discussions/23367
https://community.home-assistant.io/t/color-of-a-light-at-dashboard-tile/763766
https://community.home-assistant.io/t/tile-card-features/804265
https://community.home-assistant.io/t/add-a-color-slider-for-light-tile/779766
https://community.home-assistant.io/t/tile-card-should-support-light-colors/518026


- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
