### PR TITLE
Allow entity-filter-card to filter on other entity

### DIFF
--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -191,6 +191,9 @@ export function extractConditionEntityIds(
   const entityIds = new Set<string>();
   for (const condition of conditions) {
     if (condition.condition === "numeric_state") {
+      if (condition.entity) {
+        entityIds.add(condition.entity);
+      }
       if (
         typeof condition.above === "string" &&
         isValidEntityId(condition.above)
@@ -204,6 +207,9 @@ export function extractConditionEntityIds(
         entityIds.add(condition.below);
       }
     } else if (condition.condition === "state") {
+      if (condition.entity) {
+        entityIds.add(condition.entity);
+      }
       [
         ...(ensureArray(condition.state) ?? []),
         ...(ensureArray(condition.state_not) ?? []),
@@ -304,8 +310,8 @@ export function addEntityToCondition(
     condition.condition === "numeric_state"
   ) {
     return {
-      ...condition,
       entity: entityId,
+      ...condition,
     };
   }
   return condition;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Entity-filter card allows us to write unique state and numeric_state conditions for each entity, but it currently requires that the entity being shown is the same entity being tested with the condition. 

This seems unnecessarily restrictive, and I think we could simply allow for conditioning an entity against a state condition of a _different_ entity. 

The default behavior would stay the same, if no `entity` is provided, assume the entity being shown is the one being tested with the condition, but allow user to specify a different entity if desired. 

I use an entity-filter w/ glance card on my main home screen to show a grid of all my "states of interest", and I occasionally bump into this limitation, that the entity I want to show is only interesting when conditioned with some other entity. 



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: entity-filter
entities:
  - sensor.sun_next_dawn
  - sensor.sun_next_dusk
  - entity: sensor.sun_next_noon
    conditions:
      - condition: state
        state: "on"
        entity: input_boolean.boolean1
conditions: []
card:
  type: glance
```
![entity-filter](https://github.com/user-attachments/assets/23b38004-9176-4bad-a749-14ff656ede72)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
