### PR TITLE
Reverse the order of all modes features and toggle

### DIFF
--- a/src/panels/lovelace/card-features/hui-alarm-modes-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-alarm-modes-card-feature.ts
@@ -119,7 +119,7 @@ class HuiAlarmModeCardFeature
 
     const color = stateColorCss(this.stateObj);
 
-    const supportedModes = supportedAlarmModes(this.stateObj);
+    const supportedModes = supportedAlarmModes(this.stateObj).reverse();
 
     const options = filterModes(
       supportedModes,

--- a/src/panels/lovelace/card-features/hui-climate-hvac-modes-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-climate-hvac-modes-card-feature.ts
@@ -122,7 +122,8 @@ class HuiClimateHvacModesCardFeature
 
     const ordererHvacModes = (this.stateObj.attributes.hvac_modes || [])
       .concat()
-      .sort(compareClimateHvacModes);
+      .sort(compareClimateHvacModes)
+      .reverse();
 
     const options = filterModes(
       ordererHvacModes,

--- a/src/panels/lovelace/card-features/hui-humidifier-toggle-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-humidifier-toggle-card-feature.ts
@@ -93,7 +93,7 @@ class HuiHumidifierToggleCardFeature
 
     const color = stateColorCss(this.stateObj);
 
-    const options = ["on", "off"].map<ControlSelectOption>((entityState) => ({
+    const options = ["off", "on"].map<ControlSelectOption>((entityState) => ({
       value: entityState,
       label: this.hass!.formatEntityState(this.stateObj!, entityState),
       path: entityState === "on" ? mdiWaterPercent : mdiPower,

--- a/src/panels/lovelace/card-features/hui-water-heater-operation-modes-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-water-heater-operation-modes-card-feature.ts
@@ -110,7 +110,8 @@ class HuiWaterHeaterOperationModeCardFeature
 
     const orderedModes = (this.stateObj.attributes.operation_list || [])
       .concat()
-      .sort(compareWaterHeaterOperationMode);
+      .sort(compareWaterHeaterOperationMode)
+      .reverse();
 
     const options = filterModes(
       orderedModes,


### PR DESCRIPTION
## Proposed change

Reverse the order of modes in cards feature to be consistent with https://github.com/home-assistant/frontend/pull/24416 so "active" mode will always appear on the right.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
