### PR TITLE
More height fixes in devtools/statistics

### DIFF
--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -81,7 +81,7 @@ type DisplayedStatisticData = StatisticData & {
 class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property({ type: Boolean }) public narrow = false;
+  @property({ type: Boolean, reflect: true }) public narrow = false;
 
   @state() private _data: StatisticData[] = [] as StatisticsMetaData[];
 
@@ -307,7 +307,7 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
     </ha-assist-chip>`;
 
     return html`
-      <div>
+      <div class="table-with-toolbars">
         ${this._selectMode
           ? html`<div class="selection-bar">
               <div class="selection-controls">
@@ -700,14 +700,15 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
           height: 100%;
         }
 
+        .table-with-toolbars {
+          height: 100%;
+          display: flex;
+          flex-direction: column;
+        }
         ha-data-table {
           width: 100%;
-          height: 100%;
+          flex-grow: 1;
           --data-table-border-width: 0;
-        }
-        :host(:not([narrow])) ha-data-table {
-          height: calc(100vh - 1px - var(--header-height) - 48px);
-          display: block;
         }
 
         :host([narrow]) {

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -749,7 +749,6 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
         .selection-bar {
           background: rgba(var(--rgb-primary-color), 0.1);
           width: 100%;
-          height: 100%;
           display: flex;
           align-items: center;
           justify-content: space-between;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The height/ double-scrollbars in developer-tools statistics was partially fixed by https://github.com/home-assistant/frontend/pull/24226 but I think it still needs more:

- The narrow selectors were not working.
- The hardcoded height didn't account for the additional search bar row height in narrow mode.
- The hardcoded height didn't account for the height of the sometimes-visible selection toolbar.

Changed to use flex instead of doing pixel subtraction. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/24437
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
