### PR TITLE
Use card text align variable for header text alignment

### DIFF
--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -238,6 +238,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
     ha-markdown {
       padding: 16px;
       word-wrap: break-word;
+      text-align: var(--card-text-align, inherit);
     }
     .with-header ha-markdown {
       padding: 0 16px 16px;

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -564,7 +564,6 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
     hui-view-header {
       display: block;
-      text-align: center;
       padding: 0 var(--column-gap);
       padding-top: var(--row-gap);
       margin: auto;

--- a/src/panels/lovelace/views/hui-view-header.ts
+++ b/src/panels/lovelace/views/hui-view-header.ts
@@ -352,11 +352,11 @@ export class HuiViewHeader extends LitElement {
     }
 
     .layout .heading {
-      text-align: start;
+      --card-text-align: start;
     }
 
     .layout.center .heading {
-      text-align: center;
+      --card-text-align: center;
       display: flex;
       flex-direction: column;
       align-items: center;


### PR DESCRIPTION
## Proposed change

Use card text align variable for header text alignment do avoid center every text of every card if the user want to use another card inside the header.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
