### PR TITLE
Fix inconsistent color picker height across browsers

### DIFF
--- a/src/components/ha-textfield.ts
+++ b/src/components/ha-textfield.ts
@@ -149,6 +149,10 @@ export class HaTextField extends TextFieldBase {
         text-align: var(--text-field-text-align, start);
       }
 
+      input[type="color"] {
+        height: 20px;
+      }
+
       /* Edge, hide reveal password icon */
       ::-ms-reveal {
         display: none;
@@ -159,6 +163,10 @@ export class HaTextField extends TextFieldBase {
       :host([no-spinner]) input::-webkit-inner-spin-button {
         -webkit-appearance: none;
         margin: 0;
+      }
+
+      input[type="color"]::-webkit-color-swatch-wrapper {
+        padding: 0;
       }
 
       /* Firefox */


### PR DESCRIPTION
## Proposed change
This PR fixes the inconsistency in the height of the color picker as part of the theme selector across browsers. In Firefox, the color picker height was rendering taller than in other browsers, causing the color inputs to overlap with their labels. To fix this, the color swatch wrapper in Chrome, Safari, and similar browsers has had its padding set to 0 in order to ensure that the height of the input is rendered consistently.


Firefox (before):
<img width="589" alt="Image" src="https://github.com/user-attachments/assets/9ca30e12-cec9-40cd-a4bc-9be2ba27ec9a" />

Firefox (after):
<img width="591" alt="image" src="https://github.com/user-attachments/assets/43f4120e-20b2-405c-bfde-83f97244c452" />

Chrome (before):
<img width="593" alt="Image" src="https://github.com/user-attachments/assets/18f6c156-ffde-47e2-96d2-103702313617" />

Chrome (after):
<img width="587" alt="image" src="https://github.com/user-attachments/assets/263ef3c9-3146-4c66-a169-7633a2b1fa31" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #24475

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
