### PR TITLE
Landingpage add core checks before show errors

### DIFF
--- a/landing-page/src/components/landing-page-logs.ts
+++ b/landing-page/src/components/landing-page-logs.ts
@@ -23,7 +23,7 @@ import { fireEvent } from "../../../src/common/dom/fire_event";
 import { fileDownload } from "../../../src/util/file_download";
 import { getSupervisorLogs, getSupervisorLogsFollow } from "../data/supervisor";
 import { waitForSeconds } from "../../../src/common/util/wait";
-import { CORE_CHECK_SECONDS } from "../ha-landing-page";
+import { ASSUME_CORE_START_SECONDS } from "../ha-landing-page";
 
 const ERROR_CHECK = /^[\d\s-:]+(ERROR|CRITICAL)(.*)/gm;
 declare global {
@@ -254,7 +254,7 @@ class LandingPageLogs extends LitElement {
       this._scheduleObserverLogs();
     } catch (err) {
       // wait because there is a moment where landingpage is down and core is not up yet
-      await waitForSeconds(CORE_CHECK_SECONDS);
+      await waitForSeconds(ASSUME_CORE_START_SECONDS);
 
       // eslint-disable-next-line no-console
       console.error(err);

--- a/landing-page/src/components/landing-page-network.ts
+++ b/landing-page/src/components/landing-page-network.ts
@@ -22,8 +22,6 @@ class LandingPageNetwork extends LitElement {
   @property({ attribute: false })
   public localize!: LocalizeFunc<LandingPageKeys>;
 
-  @property({ attribute: false }) public checkCore!: () => Promise<boolean>;
-
   @property({ attribute: false }) public networkInfo?: NetworkInfo;
 
   @property({ type: Boolean }) public error = false;

--- a/landing-page/src/components/landing-page-network.ts
+++ b/landing-page/src/components/landing-page-network.ts
@@ -30,6 +30,8 @@ class LandingPageNetwork extends LitElement {
   @property({ attribute: false })
   public localize!: LocalizeFunc<LandingPageKeys>;
 
+  @property({ attribute: false }) public checkCore!: () => Promise<boolean>;
+
   @state() private _networkIssue = false;
 
   @state() private _getNetworkInfoError = false;
@@ -127,11 +129,14 @@ class LandingPageNetwork extends LitElement {
 
       ({ data } = await response.json());
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-      this._getNetworkInfoError = true;
-      this._dnsPrimaryInterfaceNameservers = undefined;
-      this._dnsPrimaryInterface = undefined;
+      const coreUp = this.checkCore();
+      if (!coreUp) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+        this._getNetworkInfoError = true;
+        this._dnsPrimaryInterfaceNameservers = undefined;
+        this._dnsPrimaryInterface = undefined;
+      }
       return;
     }
 

--- a/landing-page/src/components/landing-page-network.ts
+++ b/landing-page/src/components/landing-page-network.ts
@@ -1,13 +1,7 @@
 import "@material/mwc-linear-progress/mwc-linear-progress";
-import {
-  type CSSResultGroup,
-  LitElement,
-  type PropertyValues,
-  css,
-  html,
-  nothing,
-} from "lit";
-import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { type CSSResultGroup, LitElement, css, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
 import type {
   LandingPageKeys,
   LocalizeFunc,
@@ -16,14 +10,12 @@ import "../../../src/components/ha-button";
 import "../../../src/components/ha-alert";
 import {
   ALTERNATIVE_DNS_SERVERS,
-  getSupervisorNetworkInfo,
-  pingSupervisor,
   setSupervisorNetworkDns,
+  type NetworkInfo,
 } from "../data/supervisor";
-import { fireEvent } from "../../../src/common/dom/fire_event";
 import { showAlertDialog } from "../../../src/dialogs/generic/show-dialog-box";
-
-const SCHEDULE_FETCH_NETWORK_INFO_SECONDS = 5;
+import type { NetworkInterface } from "../../../src/data/hassio/network";
+import { fireEvent } from "../../../src/common/dom/fire_event";
 
 @customElement("landing-page-network")
 class LandingPageNetwork extends LitElement {
@@ -32,25 +24,27 @@ class LandingPageNetwork extends LitElement {
 
   @property({ attribute: false }) public checkCore!: () => Promise<boolean>;
 
-  @state() private _networkIssue = false;
+  @property({ attribute: false }) public networkInfo?: NetworkInfo;
 
-  @state() private _getNetworkInfoError = false;
-
-  @state() private _dnsPrimaryInterfaceNameservers?: string;
-
-  @state() private _dnsPrimaryInterface?: string;
+  @property({ type: Boolean }) public error = false;
 
   protected render() {
-    if (!this._networkIssue && !this._getNetworkInfoError) {
-      return nothing;
-    }
-
-    if (this._getNetworkInfoError) {
+    if (this.error) {
       return html`
         <ha-alert alert-type="error">
           <p>${this.localize("network_issue.error_get_network_info")}</p>
         </ha-alert>
       `;
+    }
+
+    let dnsPrimaryInterfaceNameservers: string | undefined;
+
+    const primaryInterface = this._getPrimaryInterface(
+      this.networkInfo?.interfaces
+    );
+    if (primaryInterface) {
+      dnsPrimaryInterfaceNameservers =
+        this._getPrimaryNameservers(primaryInterface);
     }
 
     return html`
@@ -60,11 +54,11 @@ class LandingPageNetwork extends LitElement {
       >
         <p>
           ${this.localize("network_issue.description", {
-            dns: this._dnsPrimaryInterfaceNameservers || "?",
+            dns: dnsPrimaryInterfaceNameservers || "?",
           })}
         </p>
         <p>${this.localize("network_issue.resolve_different")}</p>
-        ${!this._dnsPrimaryInterfaceNameservers
+        ${!dnsPrimaryInterfaceNameservers
           ? html`
               <p>
                 <b>${this.localize("network_issue.no_primary_interface")} </b>
@@ -76,7 +70,7 @@ class LandingPageNetwork extends LitElement {
             ({ translationKey }, key) =>
               html`<ha-button
                 .index=${key}
-                .disabled=${!this._dnsPrimaryInterfaceNameservers}
+                .disabled=${!dnsPrimaryInterfaceNameservers}
                 @click=${this._setDns}
                 >${this.localize(translationKey)}</ha-button
               >`
@@ -86,100 +80,40 @@ class LandingPageNetwork extends LitElement {
     `;
   }
 
-  protected firstUpdated(_changedProperties: PropertyValues): void {
-    super.firstUpdated(_changedProperties);
-    this._pingSupervisor();
-  }
+  private _getPrimaryInterface = memoizeOne((interfaces?: NetworkInterface[]) =>
+    interfaces?.find((intf) => intf.primary && intf.enabled)
+  );
 
-  private _schedulePingSupervisor() {
-    setTimeout(
-      () => this._pingSupervisor(),
-      SCHEDULE_FETCH_NETWORK_INFO_SECONDS * 1000
-    );
-  }
-
-  private async _pingSupervisor() {
-    try {
-      const response = await pingSupervisor();
-      if (!response.ok) {
-        throw new Error("Failed to ping supervisor, assume update in progress");
-      }
-      this._fetchSupervisorInfo();
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-      this._schedulePingSupervisor();
-    }
-  }
-
-  private _scheduleFetchSupervisorInfo() {
-    setTimeout(
-      () => this._fetchSupervisorInfo(),
-      SCHEDULE_FETCH_NETWORK_INFO_SECONDS * 1000
-    );
-  }
-
-  private async _fetchSupervisorInfo() {
-    let data;
-    try {
-      const response = await getSupervisorNetworkInfo();
-      if (!response.ok) {
-        throw new Error("Failed to fetch network info");
-      }
-
-      ({ data } = await response.json());
-    } catch (err) {
-      const coreUp = this.checkCore();
-      if (!coreUp) {
-        // eslint-disable-next-line no-console
-        console.error(err);
-        this._getNetworkInfoError = true;
-        this._dnsPrimaryInterfaceNameservers = undefined;
-        this._dnsPrimaryInterface = undefined;
-      }
-      return;
-    }
-
-    this._getNetworkInfoError = false;
-
-    const primaryInterface = data.interfaces.find(
-      (intf) => intf.primary && intf.enabled
-    );
-    if (primaryInterface) {
-      this._dnsPrimaryInterfaceNameservers = [
+  private _getPrimaryNameservers = memoizeOne(
+    (primaryInterface: NetworkInterface) =>
+      [
         ...(primaryInterface.ipv4?.nameservers || []),
         ...(primaryInterface.ipv6?.nameservers || []),
-      ].join(", ");
-
-      this._dnsPrimaryInterface = primaryInterface.interface;
-    } else {
-      this._dnsPrimaryInterfaceNameservers = undefined;
-      this._dnsPrimaryInterface = undefined;
-    }
-
-    if (!data.host_internet) {
-      this._networkIssue = true;
-    } else {
-      this._networkIssue = false;
-    }
-
-    fireEvent(this, "value-changed", {
-      value: this._networkIssue,
-    });
-    this._scheduleFetchSupervisorInfo();
-  }
+      ].join(", ")
+  );
 
   private async _setDns(ev) {
+    const primaryInterface = this._getPrimaryInterface(
+      this.networkInfo?.interfaces
+    );
+
     const index = ev.target?.index;
     try {
+      const dnsPrimaryInterface = primaryInterface?.interface;
+      if (!dnsPrimaryInterface) {
+        throw new Error("No primary interface found");
+      }
+
       const response = await setSupervisorNetworkDns(
         index,
-        this._dnsPrimaryInterface!
+        dnsPrimaryInterface
       );
       if (!response.ok) {
         throw new Error("Failed to set DNS");
       }
-      this._networkIssue = false;
+
+      // notify landing page to trigger a network info reload
+      fireEvent(this, "dns-set");
     } catch (err: any) {
       // eslint-disable-next-line no-console
       console.error(err);
@@ -209,5 +143,8 @@ class LandingPageNetwork extends LitElement {
 declare global {
   interface HTMLElementTagNameMap {
     "landing-page-network": LandingPageNetwork;
+  }
+  interface HASSDomEvents {
+    "dns-set": undefined;
   }
 }

--- a/landing-page/src/data/supervisor.ts
+++ b/landing-page/src/data/supervisor.ts
@@ -1,4 +1,17 @@
 import type { LandingPageKeys } from "../../../src/common/translations/localize";
+import type { HassioResponse } from "../../../src/data/hassio/common";
+import type {
+  DockerNetwork,
+  NetworkInterface,
+} from "../../../src/data/hassio/network";
+import { handleFetchPromise } from "../../../src/util/hass-call-api";
+
+export interface NetworkInfo {
+  interfaces: NetworkInterface[];
+  docker: DockerNetwork;
+  host_internet: boolean;
+  supervisor_internet: boolean;
+}
 
 export const ALTERNATIVE_DNS_SERVERS: {
   ipv4: string[];
@@ -37,8 +50,11 @@ export async function pingSupervisor() {
   return fetch("/supervisor-api/supervisor/ping");
 }
 
-export async function getSupervisorNetworkInfo() {
-  return fetch("/supervisor-api/network/info");
+export async function getSupervisorNetworkInfo(): Promise<NetworkInfo> {
+  const responseData = await handleFetchPromise<HassioResponse<NetworkInfo>>(
+    fetch("/supervisor-api/network/info")
+  );
+  return responseData?.data;
 }
 
 export const setSupervisorNetworkDns = async (

--- a/landing-page/src/ha-landing-page.ts
+++ b/landing-page/src/ha-landing-page.ts
@@ -137,14 +137,7 @@ class HaLandingPage extends LandingPageBaseElement {
 
   private async _fetchSupervisorInfo(schedule = false) {
     try {
-      let first = false;
-      if (!this._networkInfo) {
-        first = true;
-      }
       this._networkInfo = await getSupervisorNetworkInfo();
-      if (first) {
-        this._networkInfo.host_internet = false;
-      }
       this._networkInfoError = false;
     } catch (err) {
       if (!this._coreStatusChecked) {

--- a/landing-page/src/ha-landing-page.ts
+++ b/landing-page/src/ha-landing-page.ts
@@ -121,7 +121,7 @@ class HaLandingPage extends LandingPageBaseElement {
     );
   }
 
-  private _scheduleTurnOfCoreCheck() {
+  private _scheduleTurnOffCoreCheck() {
     setTimeout(() => {
       this._coreCheckActive = false;
     }, ASSUME_CORE_START_SECONDS * 1000);
@@ -141,7 +141,7 @@ class HaLandingPage extends LandingPageBaseElement {
       if (!this._coreStatusChecked) {
         // wait before show errors, because we assume that core is starting
         this._coreCheckActive = true;
-        this._scheduleTurnOfCoreCheck();
+        this._scheduleTurnOffCoreCheck();
       }
       await this._checkCoreAvailability();
 

--- a/landing-page/src/ha-landing-page.ts
+++ b/landing-page/src/ha-landing-page.ts
@@ -17,7 +17,7 @@ import {
 } from "./data/supervisor";
 
 export const ASSUME_CORE_START_SECONDS = 30;
-export const SCHEDULE_CORE_CHECK_SECONDS = 5;
+export const SCHEDULE_CORE_CHECK_SECONDS = 1;
 const SCHEDULE_FETCH_NETWORK_INFO_SECONDS = 5;
 
 @customElement("ha-landing-page")

--- a/landing-page/src/ha-landing-page.ts
+++ b/landing-page/src/ha-landing-page.ts
@@ -139,12 +139,13 @@ class HaLandingPage extends LandingPageBaseElement {
     try {
       this._networkInfo = await getSupervisorNetworkInfo();
       this._networkInfoError = false;
+      this._coreStatusChecked = false;
     } catch (err) {
       if (!this._coreStatusChecked) {
         // wait because there is a moment where landingpage is down and core is not up yet
         await waitForSeconds(CORE_CHECK_SECONDS);
-        await this._checkCoreAvailability();
       }
+      await this._checkCoreAvailability();
       // eslint-disable-next-line no-console
       console.error(err);
       this._networkInfoError = true;
@@ -153,10 +154,6 @@ class HaLandingPage extends LandingPageBaseElement {
     if (schedule) {
       this._scheduleFetchSupervisorInfo();
     }
-  }
-
-  private _scheduleCheckCoreAvailability() {
-    setTimeout(() => this._checkCoreAvailability(), CORE_CHECK_SECONDS * 1000);
   }
 
   private async _checkCoreAvailability() {
@@ -169,8 +166,6 @@ class HaLandingPage extends LandingPageBaseElement {
       }
     } catch (_err) {
       this._coreStatusChecked = true;
-      // checking core if it takes longer than 5 seconds to start
-      this._scheduleCheckCoreAvailability();
     }
   }
 

--- a/src/common/util/wait.ts
+++ b/src/common/util/wait.ts
@@ -1,0 +1,6 @@
+export const waitForMs = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export const waitForSeconds = (seconds: number) => waitForMs(seconds * 1000);

--- a/src/data/hassio/network.ts
+++ b/src/data/hassio/network.ts
@@ -21,7 +21,7 @@ export interface NetworkInterface {
   wifi?: Partial<WifiConfiguration> | null;
 }
 
-interface DockerNetwork {
+export interface DockerNetwork {
   address: string;
   dns: string;
   gateway: string;


### PR DESCRIPTION
## Proposed change
- Show no errors when landingpage backend is down but core is not up yet.

Closes home-assistant/landingpage#147


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
