### PR TITLE
Allow automation/script creation directly from clipboard

### DIFF
--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -474,3 +474,16 @@ export const migrateAutomationAction = (
 
   return action;
 };
+
+export const normalizeScriptConfig = (config: ScriptConfig): ScriptConfig => {
+  // Normalize data: ensure sequence is a list
+  // Happens when people copy paste their scripts into the config
+  const value = config.sequence;
+  if (value && !Array.isArray(value)) {
+    config.sequence = [value];
+  }
+  if (config.sequence) {
+    config.sequence = migrateAutomationAction(config.sequence);
+  }
+  return config;
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3478,8 +3478,9 @@
             "header": "Create automation",
             "create_empty": "Create new automation",
             "create_empty_description": "Start with an empty automation from scratch",
-            "create_from_clipboard": "Create from clipboard",
+            "create_from_clipboard": "Paste from clipboard",
             "create_from_clipboard_description": "Paste an automation from your clipboard",
+            "create_from_clipboard_permission": "Home Assistant will request permission to read your clipboard.",
             "create_blueprint": "Create from blueprint",
             "create_blueprint_description": "Discover community blueprints",
             "blueprint_source": {
@@ -4387,8 +4388,9 @@
             "header": "Create script",
             "create_empty": "Create new script",
             "create_empty_description": "Start with an empty script from scratch",
-            "create_from_clipboard": "Create from clipboard",
+            "create_from_clipboard": "Paste from clipboard",
             "create_from_clipboard_description": "Paste a script from your clipboard",
+            "create_from_clipboard_permission": "[%key:ui::panel::config::automation::dialog_new::create_from_clipboard_permission%]",
             "create_blueprint": "[%key:ui::panel::config::automation::dialog_new::create_blueprint%]",
             "create_blueprint_description": "[%key:ui::panel::config::automation::dialog_new::create_blueprint_description%]",
             "blueprint_source": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3478,6 +3478,8 @@
             "header": "Create automation",
             "create_empty": "Create new automation",
             "create_empty_description": "Start with an empty automation from scratch",
+            "create_from_clipboard": "Create from clipboard",
+            "create_from_clipboard_description": "Paste an automation from your clipboard",
             "create_blueprint": "Create from blueprint",
             "create_blueprint_description": "Discover community blueprints",
             "blueprint_source": {
@@ -4385,6 +4387,8 @@
             "header": "Create script",
             "create_empty": "Create new script",
             "create_empty_description": "Start with an empty script from scratch",
+            "create_from_clipboard": "Create from clipboard",
+            "create_from_clipboard_description": "Paste a script from your clipboard",
             "create_blueprint": "[%key:ui::panel::config::automation::dialog_new::create_blueprint%]",
             "create_blueprint_description": "[%key:ui::panel::config::automation::dialog_new::create_blueprint_description%]",
             "blueprint_source": {


### PR DESCRIPTION
## Proposed change
Imagine you copied a automation or script YAML and want to create a new automation from it, you would have to create a new automation/script, switch to YAML mode, paste it and maybe switch back, if you want have the UI mode.
This PR adds now the ability to detect automation/script YAML in the clipboard and provide a option when creating a automation/script to directly create one from it.

Only downside on this, it only works in a secure context, or at least on Chrome when giving the clipboard permission manually.

<video src="https://github.com/user-attachments/assets/40053395-be46-4552-b56b-da530412774d" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
