### PR TITLE
Render todo items with no state, change look of read only items

### DIFF
--- a/demo/src/stubs/todo.ts
+++ b/demo/src/stubs/todo.ts
@@ -2,26 +2,35 @@ import type { TodoItem } from "../../../src/data/todo";
 import { TodoItemStatus } from "../../../src/data/todo";
 import type { MockHomeAssistant } from "../../../src/fake_data/provide_hass";
 
+const items = {
+  items: [
+    {
+      uid: "12",
+      summary: "Milk",
+      status: TodoItemStatus.NeedsAction,
+    },
+    {
+      uid: "13",
+      summary: "Eggs",
+      status: TodoItemStatus.NeedsAction,
+    },
+    {
+      uid: "14",
+      summary: "Oranges",
+      status: TodoItemStatus.Completed,
+    },
+    {
+      uid: "15",
+      summary: "Beer",
+    },
+  ] as TodoItem[],
+};
+
 export const mockTodo = (hass: MockHomeAssistant) => {
-  hass.mockWS("todo/item/list", () => ({
-    items: [
-      {
-        uid: "12",
-        summary: "Milk",
-        status: TodoItemStatus.NeedsAction,
-      },
-      {
-        uid: "13",
-        summary: "Eggs",
-        status: TodoItemStatus.NeedsAction,
-      },
-      {
-        uid: "14",
-        summary: "Oranges",
-        status: TodoItemStatus.Completed,
-      },
-    ] as TodoItem[],
-  }));
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  hass.mockWS("todo/item/subscribe", (_msg, _hass) => () => {});
+  hass.mockWS("todo/item/list", () => items);
+  hass.mockWS("todo/item/subscribe", (_msg, _hass, onChange) => {
+    onChange!(items);
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  });
 };

--- a/demo/src/stubs/todo.ts
+++ b/demo/src/stubs/todo.ts
@@ -28,6 +28,7 @@ const items = {
 
 export const mockTodo = (hass: MockHomeAssistant) => {
   hass.mockWS("todo/item/list", () => items);
+  hass.mockWS("todo/item/move", () => undefined);
   hass.mockWS("todo/item/subscribe", (_msg, _hass, onChange) => {
     onChange!(items);
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/gallery/src/pages/lovelace/todo-list-card.ts
+++ b/gallery/src/pages/lovelace/todo-list-card.ts
@@ -1,11 +1,11 @@
 import type { PropertyValues, TemplateResult } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, query } from "lit/decorators";
+import { mockIcons } from "../../../../demo/src/stubs/icons";
+import { mockTodo } from "../../../../demo/src/stubs/todo";
+import { getEntity } from "../../../../src/fake_data/entity";
 import { provideHass } from "../../../../src/fake_data/provide_hass";
 import "../../components/demo-cards";
-import { getEntity } from "../../../../src/fake_data/entity";
-import { mockTodo } from "../../../../demo/src/stubs/todo";
-import { mockIcons } from "../../../../demo/src/stubs/icons";
 
 const ENTITIES = [
   getEntity("todo", "shopping_list", "2", {

--- a/src/components/ha-check-list-item.ts
+++ b/src/components/ha-check-list-item.ts
@@ -1,10 +1,10 @@
-import { css, html } from "lit";
 import { CheckListItemBase } from "@material/mwc-list/mwc-check-list-item-base";
 import { styles as controlStyles } from "@material/mwc-list/mwc-control-list-item.css";
 import { styles } from "@material/mwc-list/mwc-list-item.css";
+import { css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import { fireEvent } from "../common/dom/fire_event";
 import { classMap } from "lit/directives/class-map";
+import { fireEvent } from "../common/dom/fire_event";
 import "./ha-checkbox";
 
 @customElement("ha-check-list-item")
@@ -27,8 +27,8 @@ export class HaCheckListItem extends CheckListItemBase {
     const graphic =
       this.graphic && this.graphic !== "control" && !this.left
         ? this.renderGraphic()
-        : html``;
-    const meta = this.hasMeta && this.left ? this.renderMeta() : html``;
+        : nothing;
+    const meta = this.hasMeta && this.left ? this.renderMeta() : nothing;
     const ripple = this.renderRipple();
 
     return html` ${ripple} ${graphic} ${this.left ? "" : text}

--- a/src/components/ha-check-list-item.ts
+++ b/src/components/ha-check-list-item.ts
@@ -1,15 +1,48 @@
-import { css } from "lit";
+import { css, html } from "lit";
 import { CheckListItemBase } from "@material/mwc-list/mwc-check-list-item-base";
 import { styles as controlStyles } from "@material/mwc-list/mwc-control-list-item.css";
 import { styles } from "@material/mwc-list/mwc-list-item.css";
-import { customElement } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
+import { classMap } from "lit/directives/class-map";
+import "./ha-checkbox";
 
 @customElement("ha-check-list-item")
 export class HaCheckListItem extends CheckListItemBase {
+  @property({ type: Boolean, attribute: "checkbox-disabled" })
+  checkboxDisabled = false;
+
   async onChange(event) {
     super.onChange(event);
     fireEvent(this, event.type);
+  }
+
+  override render() {
+    const checkboxClasses = {
+      "mdc-deprecated-list-item__graphic": this.left,
+      "mdc-deprecated-list-item__meta": !this.left,
+    };
+
+    const text = this.renderText();
+    const graphic =
+      this.graphic && this.graphic !== "control" && !this.left
+        ? this.renderGraphic()
+        : html``;
+    const meta = this.hasMeta && this.left ? this.renderMeta() : html``;
+    const ripple = this.renderRipple();
+
+    return html` ${ripple} ${graphic} ${this.left ? "" : text}
+      <span class=${classMap(checkboxClasses)}>
+        <ha-checkbox
+          reducedTouchTarget
+          tabindex=${this.tabindex}
+          .checked=${this.selected}
+          ?disabled=${this.disabled || this.checkboxDisabled}
+          @change=${this.onChange}
+        >
+        </ha-checkbox>
+      </span>
+      ${this.left ? text : ""} ${meta}`;
   }
 
   static override styles = [

--- a/src/components/ha-check-list-item.ts
+++ b/src/components/ha-check-list-item.ts
@@ -12,6 +12,9 @@ export class HaCheckListItem extends CheckListItemBase {
   @property({ type: Boolean, attribute: "checkbox-disabled" })
   checkboxDisabled = false;
 
+  @property({ type: Boolean })
+  indeterminate = false;
+
   async onChange(event) {
     super.onChange(event);
     fireEvent(this, event.type);
@@ -37,6 +40,7 @@ export class HaCheckListItem extends CheckListItemBase {
           reducedTouchTarget
           tabindex=${this.tabindex}
           .checked=${this.selected}
+          .indeterminate=${this.indeterminate}
           ?disabled=${this.disabled || this.checkboxDisabled}
           @change=${this.onChange}
         >

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -25,7 +25,7 @@ export enum TodoSortMode {
 export interface TodoItem {
   uid: string;
   summary: string;
-  status: TodoItemStatus;
+  status?: TodoItemStatus;
   description?: string | null;
   due?: string | null;
 }
@@ -72,7 +72,7 @@ export const fetchItems = async (
 export const subscribeItems = (
   hass: HomeAssistant,
   entity_id: string,
-  callback: (item) => void
+  callback: (update: TodoItems) => void
 ) =>
   hass.connection.subscribeMessage<any>(callback, {
     type: "todo/item/subscribe",

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -25,7 +25,7 @@ export enum TodoSortMode {
 export interface TodoItem {
   uid: string;
   summary: string;
-  status?: TodoItemStatus;
+  status: TodoItemStatus | null;
   description?: string | null;
   due?: string | null;
 }

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -312,7 +312,9 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
             ${itemsWithoutStatus.length
               ? html`
                   <div>
-                    <div class="divider" role="seperator"></div>
+                    ${uncheckedItems.length
+                      ? html`<div class="divider" role="seperator"></div>`
+                      : nothing}
                     <div class="header" role="seperator">
                       <h2>
                         ${this.hass!.localize(

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -673,34 +673,33 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
   }
 
   private async _moveItem(oldIndex: number, newIndex: number) {
-    // correct index for header
-    oldIndex -= 1;
-    newIndex -= 1;
-    const uncheckedItems = this._getUncheckedItems(this._items);
-    const item = uncheckedItems[oldIndex];
-    let prevItem: TodoItem | undefined;
+    await this.updateComplete;
+
+    const list = this.renderRoot.querySelector("mwc-list")!;
+
+    const itemId = (list.children[oldIndex] as any).itemId as string;
+
+    let prevItemId: string | undefined;
     if (newIndex > 0) {
       if (newIndex < oldIndex) {
-        prevItem = uncheckedItems[newIndex - 1];
+        prevItemId = (list.children[newIndex - 1] as any).itemId;
       } else {
-        prevItem = uncheckedItems[newIndex];
+        prevItemId = (list.children[newIndex] as any).itemId;
       }
     }
 
     // Optimistic change
-    const itemIndex = this._items!.findIndex((itm) => itm.uid === item.uid);
-    this._items!.splice(itemIndex, 1);
+    const itemIndex = this._items!.findIndex((itm) => itm.uid === itemId);
+    const item = this._items!.splice(itemIndex, 1)[0];
     if (newIndex === 0) {
       this._items!.unshift(item);
-    } else {
-      const prevIndex = this._items!.findIndex(
-        (itm) => itm.uid === prevItem!.uid
-      );
+    } else if (prevItemId !== undefined) {
+      const prevIndex = this._items!.findIndex((itm) => itm.uid === prevItemId);
       this._items!.splice(prevIndex + 1, 0, item);
     }
     this._items = [...this._items!];
 
-    await moveItem(this.hass!, this._entityId!, item.uid, prevItem?.uid);
+    await moveItem(this.hass!, this._entityId!, itemId, prevItemId);
   }
 
   static styles = css`

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -437,7 +437,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
               left
               .hasMeta=${showReorder || showDelete}
               class="editRow ${classMap({
-                draggable: item.status === TodoItemStatus.NeedsAction,
+                draggable: item.status !== TodoItemStatus.Completed,
                 completed: item.status === TodoItemStatus.Completed,
                 multiline: Boolean(item.description || item.due),
               })}"

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -289,6 +289,13 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
           @item-moved=${this._itemMoved}
         >
           <ha-list wrapFocus multi>
+            ${!uncheckedItems.length && !itemsWithoutStatus.length
+              ? html`<p class="empty">
+                  ${this.hass.localize(
+                    "ui.panel.lovelace.cards.todo-list.no_unchecked_items"
+                  )}
+                </p>`
+              : nothing}
             ${uncheckedItems.length
               ? html`
                   <div class="header" role="seperator">
@@ -297,46 +304,26 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                         "ui.panel.lovelace.cards.todo-list.unchecked_items"
                       )}
                     </h2>
-                    ${(!this._config.display_order ||
-                      this._config.display_order === TodoSortMode.NONE) &&
-                    this._todoListSupportsFeature(
-                      TodoListEntityFeature.MOVE_TODO_ITEM
-                    )
-                      ? html`<ha-button-menu
-                          @closed=${stopPropagation}
-                          fixed
-                          @action=${this._handlePrimaryMenuAction}
-                        >
-                          <ha-icon-button
-                            slot="trigger"
-                            .path=${mdiDotsVertical}
-                          ></ha-icon-button>
-                          <ha-list-item graphic="icon">
-                            ${this.hass!.localize(
-                              this._reordering
-                                ? "ui.panel.lovelace.cards.todo-list.exit_reorder_items"
-                                : "ui.panel.lovelace.cards.todo-list.reorder_items"
-                            )}
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiSort}
-                              .disabled=${unavailable}
-                            >
-                            </ha-svg-icon>
-                          </ha-list-item>
-                        </ha-button-menu>`
-                      : nothing}
+                    ${this._renderMenu(this._config, unavailable)}
                   </div>
                   ${this._renderItems(uncheckedItems, unavailable)}
                 `
-              : html`<p class="empty">
-                  ${this.hass.localize(
-                    "ui.panel.lovelace.cards.todo-list.no_unchecked_items"
-                  )}
-                </p>`}
+              : nothing}
             ${itemsWithoutStatus.length
               ? html`
-                  <div class="divider" role="seperator"></div>
+                  <div>
+                    <div class="divider" role="seperator"></div>
+                    <div class="header" role="seperator">
+                      <h2>
+                        ${this.hass!.localize(
+                          "ui.panel.lovelace.cards.todo-list.no_status_items"
+                        )}
+                      </h2>
+                      ${!uncheckedItems.length
+                        ? this._renderMenu(this._config, unavailable)
+                        : nothing}
+                    </div>
+                  </div>
                   ${this._renderItems(itemsWithoutStatus, unavailable)}
                 `
               : nothing}
@@ -387,6 +374,36 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
     `;
   }
 
+  private _renderMenu(config: TodoListCardConfig, unavailable: boolean) {
+    return (!config.display_order ||
+      config.display_order === TodoSortMode.NONE) &&
+      this._todoListSupportsFeature(TodoListEntityFeature.MOVE_TODO_ITEM)
+      ? html`<ha-button-menu
+          @closed=${stopPropagation}
+          fixed
+          @action=${this._handlePrimaryMenuAction}
+        >
+          <ha-icon-button
+            slot="trigger"
+            .path=${mdiDotsVertical}
+          ></ha-icon-button>
+          <ha-list-item graphic="icon">
+            ${this.hass!.localize(
+              this._reordering
+                ? "ui.panel.lovelace.cards.todo-list.exit_reorder_items"
+                : "ui.panel.lovelace.cards.todo-list.reorder_items"
+            )}
+            <ha-svg-icon
+              slot="graphic"
+              .path=${mdiSort}
+              .disabled=${unavailable}
+            >
+            </ha-svg-icon>
+          </ha-list-item>
+        </ha-button-menu>`
+      : nothing;
+  }
+
   private _getDueDate(item: TodoItem): Date | undefined {
     return item.due
       ? item.due.includes("T")
@@ -427,6 +444,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
               .checkboxDisabled=${!this._todoListSupportsFeature(
                 TodoListEntityFeature.UPDATE_TODO_ITEM
               )}
+              .indeterminate=${!item.status}
               .noninteractive=${!this._todoListSupportsFeature(
                 TodoListEntityFeature.UPDATE_TODO_ITEM
               )}

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -156,7 +156,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
     return items;
   }
 
-  private _getCheckedAndItemsWithoutStatus = memoizeOne(
+  private _getUncheckedAndItemsWithoutStatus = memoizeOne(
     (items?: TodoItem[], sort?: string | undefined): TodoItem[] =>
       items
         ? this._sortItems(

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -264,7 +264,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
     );
 
     const reorderableItems = this._reordering
-      ? this._getCheckedAndItemsWithoutStatus(
+      ? this._getUncheckedAndItemsWithoutStatus(
           this._items,
           this._config.display_order
         )
@@ -324,7 +324,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                       </h2>
                       ${this._renderMenu(this._config, unavailable)}
                     </div>
-                    ${this._renderItems(reorderableItems, unavailable)}`
+                    ${this._renderItems(reorderableItems ?? [], unavailable)}`
                 : nothing}
             ${!this._reordering && uncheckedItems.length
               ? html`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6510,6 +6510,7 @@
             "unchecked_items": "Active",
             "no_unchecked_items": "You have no to-do items!",
             "checked_items": "Completed",
+            "no_status_items": "No status",
             "clear_items": "Remove completed items",
             "add_item": "Add item",
             "today": "Today",


### PR DESCRIPTION


## Proposed change

Todo items without state would never be shown.

Read only items would be shown as disabled, now only the checkbox is disabled, and the item is made noninteractive.



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
