### PR TITLE
Update country picker dialog in onboarding

### DIFF
--- a/src/components/ha-country-picker.ts
+++ b/src/components/ha-country-picker.ts
@@ -8,7 +8,7 @@ import "./ha-list-item";
 import "./ha-select";
 import type { HaSelect } from "./ha-select";
 
-const COUNTRIES = [
+export const COUNTRIES = [
   "AD",
   "AE",
   "AF",

--- a/src/onboarding/onboarding-core-config.ts
+++ b/src/onboarding/onboarding-core-config.ts
@@ -133,7 +133,7 @@ class OnboardingCoreConfig extends LitElement {
     }
 
     // Set suggested country
-    let suggested = "NL";
+    let suggested: string | undefined;
     if (navigator.language) {
       const lang = navigator.language.split("-").pop()!.toUpperCase();
       if (COUNTRIES.includes(lang)) {

--- a/src/onboarding/onboarding-core-config.ts
+++ b/src/onboarding/onboarding-core-config.ts
@@ -7,7 +7,7 @@ import { fireEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
 import "../components/ha-alert";
 import "../components/ha-circular-progress";
-import "../components/ha-country-picker";
+import { COUNTRIES } from "../components/ha-country-picker";
 import type { ConfigUpdateValues } from "../data/core";
 import { saveCoreConfig } from "../data/core";
 import { countryCurrency } from "../data/currency";
@@ -131,6 +131,16 @@ class OnboardingCoreConfig extends LitElement {
       this._save(ev);
       return;
     }
+
+    // Set suggested country
+    if (navigator.language) {
+      let suggested = navigator.language.split("-")[1].toUpperCase();
+      if (!COUNTRIES.includes(suggested)) {
+        suggested = "NL";
+      }
+      this._country = suggested;
+    }
+
     fireEvent(this, "onboarding-progress", { increase: 0.5 });
     await this.updateComplete;
     setTimeout(

--- a/src/onboarding/onboarding-core-config.ts
+++ b/src/onboarding/onboarding-core-config.ts
@@ -133,13 +133,14 @@ class OnboardingCoreConfig extends LitElement {
     }
 
     // Set suggested country
+    let suggested = "NL";
     if (navigator.language) {
-      let suggested = navigator.language.split("-")[1].toUpperCase();
-      if (!COUNTRIES.includes(suggested)) {
-        suggested = "NL";
+      const lang = navigator.language.split("-").pop()!.toUpperCase();
+      if (COUNTRIES.includes(lang)) {
+        suggested = lang;
       }
-      this._country = suggested;
     }
+    this._country = suggested;
 
     fireEvent(this, "onboarding-progress", { increase: 0.5 });
     await this.updateComplete;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8234,7 +8234,7 @@
           "osm_privacy_policy": "Privacy policy",
           "title_location_detect": "Do you want us to detect your location?",
           "intro_location_detect": "We can detect your location by making a one-time request to an external service.",
-          "country_intro": "We would like to know the country your home is in, so we can use the correct units for you.",
+          "country_intro": "We would like to know the country your home is in, so we can use the correct units.",
           "location_name": "Name of your Home Assistant installation",
           "location_name_default": "Home",
           "address_label": "Search address",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
If you don't use the address search to set the location of your instance, we will ask you for your location. The old form had a weird word wrap with 2 words on a new line, and the country picker had nothing selected by default.

We now look at the browser locale to guess a country. If the locale is not a country code, we set `NL` to match the default location of the instance.

Before:
![CleanShot 2025-03-07 at 10 59 45@2x](https://github.com/user-attachments/assets/576c0be4-2a44-4a47-86fb-07c38824b70e)

After:
![CleanShot 2025-03-07 at 11 01 14@2x](https://github.com/user-attachments/assets/f3c801a1-f4b4-4620-a2ac-be65cc8e4414)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
