### PR TITLE
Show statistics in history card on first load

### DIFF
--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -57,6 +57,8 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
 
   private _subscribed?: Promise<(() => Promise<void>) | undefined>;
 
+  private _stateHistory?: HistoryResult;
+
   public getCardSize(): number {
     return this._config?.title ? 2 : 0 + 2 * (this._entityIds?.length || 1);
   }
@@ -123,7 +125,7 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
           return;
         }
 
-        const stateHistory = computeHistory(
+        this._stateHistory = computeHistory(
           this.hass!,
           combinedHistory,
           this._entityIds,
@@ -132,11 +134,7 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
           this._config?.split_device_classes
         );
 
-        this._history = mergeHistoryResults(
-          stateHistory,
-          this._statisticsHistory,
-          this._config?.split_device_classes
-        );
+        this._mergeHistory();
       },
       this._hoursToShow,
       this._entityIds
@@ -149,6 +147,16 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     await this._fetchStatistics(sensorNumericDeviceClasses);
 
     this._setRedrawTimer();
+  }
+
+  private _mergeHistory() {
+    if (this._stateHistory) {
+      this._history = mergeHistoryResults(
+        this._stateHistory,
+        this._statisticsHistory,
+        this._config?.split_device_classes
+      );
+    }
   }
 
   private async _fetchStatistics(sensorNumericDeviceClasses: string[]) {
@@ -173,6 +181,9 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
       sensorNumericDeviceClasses,
       this._config?.split_device_classes
     );
+
+    this._mergeHistory();
+    this._redrawGraph();
   }
 
   private _redrawGraph() {

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -183,7 +183,6 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     );
 
     this._mergeHistory();
-    this._redrawGraph();
   }
 
   private _redrawGraph() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The chart was not re-rendered with the statistics data when the fetch came back, it would only update much later. 

Fix #24495 so it's shown immediately. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24495
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
