### PR TITLE
Fix behavior of select dropdowns when options change

### DIFF
--- a/src/components/ha-control-select-menu.ts
+++ b/src/components/ha-control-select-menu.ts
@@ -1,5 +1,6 @@
 import { SelectBase } from "@material/mwc-select/mwc-select-base";
 import { mdiMenuDown } from "@mdi/js";
+import type { PropertyValues } from "lit";
 import { css, html, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -23,6 +24,16 @@ export class HaControlSelectMenu extends SelectBase {
 
   @property({ type: Boolean, attribute: "hide-label" })
   public hideLabel = false;
+
+  @property() public options;
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+    if (changedProps.get("options")) {
+      this.layoutOptions();
+      this.selectByValue(this.value);
+    }
+  }
 
   public override render() {
     const classes = {

--- a/src/components/ha-select.ts
+++ b/src/components/ha-select.ts
@@ -17,6 +17,8 @@ export class HaSelect extends SelectBase {
   @property({ attribute: "inline-arrow", type: Boolean })
   public inlineArrow = false;
 
+  @property() public options;
+
   protected override render() {
     return html`
       ${super.render()}
@@ -67,6 +69,10 @@ export class HaSelect extends SelectBase {
       } else {
         textContainerElement?.classList.remove("inline-arrow");
       }
+    }
+    if (changedProperties.get("options")) {
+      this.layoutOptions();
+      this.selectByValue(this.value);
     }
   }
 

--- a/src/panels/lovelace/card-features/hui-select-options-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-select-options-card-feature.ts
@@ -75,14 +75,6 @@ class HuiSelectOptionsCardFeature
           oldHass?.formatEntityAttributeValue
       ) {
         this._haSelect.layoutOptions();
-        if (this.stateObj) {
-          const newIdx = this.stateObj.attributes.options.findIndex(
-            (option) => option === this.stateObj!.state
-          );
-          if (newIdx >= 0) {
-            this._haSelect.select(newIdx);
-          }
-        }
       }
     }
   }
@@ -138,6 +130,7 @@ class HuiSelectOptionsCardFeature
         hide-label
         .label=${this.hass.localize("ui.card.select.option")}
         .value=${stateObj.state}
+        .options=${options}
         .disabled=${this.stateObj.state === UNAVAILABLE}
         fixedMenuPosition
         naturalMenuWidth

--- a/src/panels/lovelace/card-features/hui-select-options-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-select-options-card-feature.ts
@@ -2,6 +2,7 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import "../../../components/ha-control-select-menu";
@@ -119,7 +120,7 @@ class HuiSelectOptionsCardFeature
 
     const stateObj = this.stateObj;
 
-    const options = filterModes(
+    const options = this._getOptions(
       this.stateObj.attributes.options,
       this._config.options
     );
@@ -147,6 +148,11 @@ class HuiSelectOptionsCardFeature
       </ha-control-select-menu>
     `;
   }
+
+  private _getOptions = memoizeOne(
+    (attributeOptions: string[], configOptions: string[] | undefined) =>
+      filterModes(attributeOptions, configOptions)
+  );
 
   static get styles() {
     return cardFeatureStyles;

--- a/src/panels/lovelace/card-features/hui-select-options-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-select-options-card-feature.ts
@@ -75,6 +75,14 @@ class HuiSelectOptionsCardFeature
           oldHass?.formatEntityAttributeValue
       ) {
         this._haSelect.layoutOptions();
+        if (this.stateObj) {
+          const newIdx = this.stateObj.attributes.options.findIndex(
+            (option) => option === this.stateObj!.state
+          );
+          if (newIdx >= 0) {
+            this._haSelect.select(newIdx);
+          }
+        }
       }
     }
   }
@@ -84,7 +92,11 @@ class HuiSelectOptionsCardFeature
 
     const oldOption = this.stateObj!.state;
 
-    if (option === oldOption) return;
+    if (
+      option === oldOption ||
+      !this.stateObj!.attributes.options.includes(option)
+    )
+      return;
 
     this._currentOption = option;
 

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -55,6 +55,12 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
         stateObj.attributes.options !== oldStateObj?.attributes.options
       ) {
         this._haSelect.layoutOptions();
+        const newIdx = stateObj.attributes.options.findIndex(
+          (option) => option === stateObj.state
+        );
+        if (newIdx >= 0) {
+          this._haSelect.select(newIdx);
+        }
       }
     }
   }

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -1,11 +1,10 @@
 import "@material/mwc-list/mwc-list-item";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/ha-select";
-import type { HaSelect } from "../../../components/ha-select";
 import { UNAVAILABLE } from "../../../data/entity";
 import { forwardHaptic } from "../../../data/haptics";
 import type { InputSelectEntity } from "../../../data/input_select";
@@ -23,8 +22,6 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
 
   @state() private _config?: EntitiesCardEntityConfig;
 
-  @query("ha-select") private _haSelect!: HaSelect;
-
   public setConfig(config: EntitiesCardEntityConfig): void {
     if (!config || !config.entity) {
       throw new Error("Entity must be specified");
@@ -35,34 +32,6 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     return hasConfigOrEntityChanged(this, changedProps);
-  }
-
-  protected updated(changedProps: PropertyValues) {
-    super.updated(changedProps);
-    if (!this._config) {
-      return;
-    }
-    if (changedProps.has("hass")) {
-      const oldHass = changedProps.get("hass");
-      const stateObj = this.hass?.states[this._config.entity] as
-        | InputSelectEntity
-        | undefined;
-      const oldStateObj = oldHass?.states[this._config.entity] as
-        | InputSelectEntity
-        | undefined;
-      if (
-        stateObj &&
-        stateObj.attributes.options !== oldStateObj?.attributes.options
-      ) {
-        this._haSelect.layoutOptions();
-        const newIdx = stateObj.attributes.options.findIndex(
-          (option) => option === stateObj.state
-        );
-        if (newIdx >= 0) {
-          this._haSelect.select(newIdx);
-        }
-      }
-    }
   }
 
   protected render() {
@@ -91,6 +60,7 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
         <ha-select
           .label=${this._config.name || computeStateName(stateObj)}
           .value=${stateObj.state}
+          .options=${stateObj.attributes.options}
           .disabled=${
             stateObj.state === UNAVAILABLE /* UNKNOWN state is allowed */
           }

--- a/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
@@ -1,11 +1,10 @@
 import "@material/mwc-list/mwc-list-item";
 import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/ha-select";
-import type { HaSelect } from "../../../components/ha-select";
 import { UNAVAILABLE } from "../../../data/entity";
 import { forwardHaptic } from "../../../data/haptics";
 import type { SelectEntity } from "../../../data/select";
@@ -23,8 +22,6 @@ class HuiSelectEntityRow extends LitElement implements LovelaceRow {
 
   @state() private _config?: EntitiesCardEntityConfig;
 
-  @query("ha-select") private _haSelect!: HaSelect;
-
   public setConfig(config: EntitiesCardEntityConfig): void {
     if (!config || !config.entity) {
       throw new Error("Entity must be specified");
@@ -35,34 +32,6 @@ class HuiSelectEntityRow extends LitElement implements LovelaceRow {
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     return hasConfigOrEntityChanged(this, changedProps);
-  }
-
-  protected updated(changedProps: PropertyValues) {
-    super.updated(changedProps);
-    if (!this._config) {
-      return;
-    }
-    if (changedProps.has("hass")) {
-      const oldHass = changedProps.get("hass");
-      const stateObj = this.hass?.states[this._config.entity] as
-        | SelectEntity
-        | undefined;
-      const oldStateObj = oldHass?.states[this._config.entity] as
-        | SelectEntity
-        | undefined;
-      if (
-        stateObj &&
-        stateObj.attributes.options !== oldStateObj?.attributes.options
-      ) {
-        this._haSelect.layoutOptions();
-        const newIdx = stateObj.attributes.options.findIndex(
-          (option) => option === stateObj.state
-        );
-        if (newIdx >= 0) {
-          this._haSelect.select(newIdx);
-        }
-      }
-    }
   }
 
   protected render() {
@@ -91,6 +60,7 @@ class HuiSelectEntityRow extends LitElement implements LovelaceRow {
         <ha-select
           .label=${this._config.name || computeStateName(stateObj)}
           .value=${stateObj.state}
+          .options=${stateObj.attributes.options}
           .disabled=${stateObj.state === UNAVAILABLE}
           naturalMenuWidth
           @action=${this._handleAction}

--- a/src/state-summary/state-card-input_select.ts
+++ b/src/state-summary/state-card-input_select.ts
@@ -1,8 +1,8 @@
 import "@material/mwc-list/mwc-list-item";
 import "../components/ha-select";
-import type { TemplateResult, PropertyValues } from "lit";
+import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
-import { customElement, property, query } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { stopPropagation } from "../common/dom/stop_propagation";
 import { computeStateName } from "../common/entity/compute_state_name";
 import "../components/entity/state-badge";
@@ -10,7 +10,6 @@ import { UNAVAILABLE } from "../data/entity";
 import type { InputSelectEntity } from "../data/input_select";
 import { setInputSelectOption } from "../data/input_select";
 import type { HomeAssistant } from "../types";
-import type { HaSelect } from "../components/ha-select";
 
 @customElement("state-card-input_select")
 class StateCardInputSelect extends LitElement {
@@ -18,33 +17,13 @@ class StateCardInputSelect extends LitElement {
 
   @property({ attribute: false }) public stateObj!: InputSelectEntity;
 
-  @query("ha-select", true) private _haSelect!: HaSelect;
-
-  protected updated(changedProps: PropertyValues) {
-    super.updated(changedProps);
-    if (changedProps.has("stateObj")) {
-      const oldState = changedProps.get("stateObj");
-      if (
-        oldState &&
-        this.stateObj.attributes.options !== oldState.attributes.options
-      ) {
-        this._haSelect.layoutOptions();
-        const newIdx = this.stateObj.attributes.options.findIndex(
-          (option) => option === this.stateObj.state
-        );
-        if (newIdx >= 0) {
-          this._haSelect.select(newIdx);
-        }
-      }
-    }
-  }
-
   protected render(): TemplateResult {
     return html`
       <state-badge .hass=${this.hass} .stateObj=${this.stateObj}></state-badge>
       <ha-select
         .label=${computeStateName(this.stateObj)}
         .value=${this.stateObj.state}
+        .options=${this.stateObj.attributes.options}
         .disabled=${
           this.stateObj.state === UNAVAILABLE /* UNKNOWN state is allowed */
         }

--- a/src/state-summary/state-card-input_select.ts
+++ b/src/state-summary/state-card-input_select.ts
@@ -29,6 +29,12 @@ class StateCardInputSelect extends LitElement {
         this.stateObj.attributes.options !== oldState.attributes.options
       ) {
         this._haSelect.layoutOptions();
+        const newIdx = this.stateObj.attributes.options.findIndex(
+          (option) => option === this.stateObj.state
+        );
+        if (newIdx >= 0) {
+          this._haSelect.select(newIdx);
+        }
       }
     }
   }

--- a/src/state-summary/state-card-select.ts
+++ b/src/state-summary/state-card-select.ts
@@ -1,7 +1,7 @@
 import "@material/mwc-list/mwc-list-item";
-import type { PropertyValues, TemplateResult } from "lit";
+import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
-import { customElement, property, query } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { stopPropagation } from "../common/dom/stop_propagation";
 import { computeStateName } from "../common/entity/compute_state_name";
 import "../components/entity/state-badge";
@@ -10,7 +10,6 @@ import { UNAVAILABLE } from "../data/entity";
 import type { SelectEntity } from "../data/select";
 import { setSelectOption } from "../data/select";
 import type { HomeAssistant } from "../types";
-import type { HaSelect } from "../components/ha-select";
 
 @customElement("state-card-select")
 class StateCardSelect extends LitElement {
@@ -18,33 +17,13 @@ class StateCardSelect extends LitElement {
 
   @property({ attribute: false }) public stateObj!: SelectEntity;
 
-  @query("ha-select", true) private _haSelect!: HaSelect;
-
-  protected updated(changedProps: PropertyValues) {
-    super.updated(changedProps);
-    if (changedProps.has("stateObj")) {
-      const oldState = changedProps.get("stateObj");
-      if (
-        oldState &&
-        this.stateObj.attributes.options !== oldState.attributes.options
-      ) {
-        this._haSelect.layoutOptions();
-        const newIdx = this.stateObj.attributes.options.findIndex(
-          (option) => option === this.stateObj.state
-        );
-        if (newIdx >= 0) {
-          this._haSelect.select(newIdx);
-        }
-      }
-    }
-  }
-
   protected render(): TemplateResult {
     return html`
       <state-badge .hass=${this.hass} .stateObj=${this.stateObj}></state-badge>
       <ha-select
         .value=${this.stateObj.state}
         .label=${computeStateName(this.stateObj)}
+        .options=${this.stateObj.attributes.options}
         .disabled=${this.stateObj.state === UNAVAILABLE}
         naturalMenuWidth
         fixedMenuPosition

--- a/src/state-summary/state-card-select.ts
+++ b/src/state-summary/state-card-select.ts
@@ -1,7 +1,7 @@
 import "@material/mwc-list/mwc-list-item";
-import type { TemplateResult } from "lit";
+import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import { stopPropagation } from "../common/dom/stop_propagation";
 import { computeStateName } from "../common/entity/compute_state_name";
 import "../components/entity/state-badge";
@@ -10,12 +10,34 @@ import { UNAVAILABLE } from "../data/entity";
 import type { SelectEntity } from "../data/select";
 import { setSelectOption } from "../data/select";
 import type { HomeAssistant } from "../types";
+import type { HaSelect } from "../components/ha-select";
 
 @customElement("state-card-select")
 class StateCardSelect extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public stateObj!: SelectEntity;
+
+  @query("ha-select", true) private _haSelect!: HaSelect;
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+    if (changedProps.has("stateObj")) {
+      const oldState = changedProps.get("stateObj");
+      if (
+        oldState &&
+        this.stateObj.attributes.options !== oldState.attributes.options
+      ) {
+        this._haSelect.layoutOptions();
+        const newIdx = this.stateObj.attributes.options.findIndex(
+          (option) => option === this.stateObj.state
+        );
+        if (newIdx >= 0) {
+          this._haSelect.select(newIdx);
+        }
+      }
+    }
+  }
 
   protected render(): TemplateResult {
     return html`


### PR DESCRIPTION
## Proposed change

When a select or input_select changes its options, seems we need to do both:

1) Rerun layoutOptions.
2) If the state still matches one of the items in the select options, but the position has moved, we need to manually find and `select` it at its new position, or else there are UI bugs with the dropdown.

Previously I had updated `input_select` to do step 1, and copied this code to also do for `select` which was missing it, but then I discovered that they both need to do step 2 as well.

Fixes bugs in entities card, tile card select feature, and the more-info state-card. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24596
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
