### PR TITLE
Handle short form hex colors in conversion functions

### DIFF
--- a/src/common/color/convert-color.ts
+++ b/src/common/color/convert-color.ts
@@ -132,10 +132,14 @@ export const hs2rgb = (hs: [number, number]): [number, number, number] =>
 
 export function theme2hex(themeColor: string): string {
   if (themeColor.startsWith("#")) {
-    if (themeColor.length === 4) {
+    if (themeColor.length === 4 || themeColor.length === 5) {
       const c = themeColor;
-      // Convert short-form hex (#abc) to 6 digit (#aabbcc)
+      // Convert short-form hex (#abc) to 6 digit (#aabbcc). Ignore alpha channel.
       return `#${c[1]}${c[1]}${c[2]}${c[2]}${c[3]}${c[3]}`;
+    }
+    if (themeColor.length === 9) {
+      // Ignore alpha channel.
+      return themeColor.substring(0, 7);
     }
     return themeColor;
   }

--- a/src/common/color/convert-color.ts
+++ b/src/common/color/convert-color.ts
@@ -132,6 +132,11 @@ export const hs2rgb = (hs: [number, number]): [number, number, number] =>
 
 export function theme2hex(themeColor: string): string {
   if (themeColor.startsWith("#")) {
+    if (themeColor.length === 4) {
+      const c = themeColor;
+      // Convert short-form hex (#abc) to 6 digit (#aabbcc)
+      return `#${c[1]}${c[1]}${c[2]}${c[2]}${c[3]}${c[3]}`;
+    }
     return themeColor;
   }
 

--- a/test/common/color/convert-color.test.ts
+++ b/test/common/color/convert-color.test.ts
@@ -50,6 +50,7 @@ describe("Color Conversion Tests", () => {
     expect(theme2hex("red")).toBe("#ff0000");
     expect(theme2hex("#ff0000")).toBe("#ff0000");
     expect(theme2hex("unicorn")).toBe("unicorn");
+    expect(theme2hex("#abc")).toBe("#aabbcc");
   });
 
   it("should convert rgb theme color to hex", () => {

--- a/test/common/color/convert-color.test.ts
+++ b/test/common/color/convert-color.test.ts
@@ -46,11 +46,13 @@ describe("Color Conversion Tests", () => {
     expect(hs2rgb(hs)).toEqual([255, 0, 0]);
   });
 
-  it("should convert theme color to hex", () => {
+  it("should convert theme color to hex (ignoring alpha)", () => {
     expect(theme2hex("red")).toBe("#ff0000");
     expect(theme2hex("#ff0000")).toBe("#ff0000");
     expect(theme2hex("unicorn")).toBe("unicorn");
     expect(theme2hex("#abc")).toBe("#aabbcc");
+    expect(theme2hex("#abcd")).toBe("#aabbcc");
+    expect(theme2hex("#aabbccdd")).toBe("#aabbcc");
   });
 
   it("should convert rgb theme color to hex", () => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Some themes use short form hex codes like `#F00`, but our color converters don't understand this for things like graph colors and energy dashboard. 

We can handle this by converting to long form in the theme conversion function. 

Also update to strip alpha codes from hex colors, in case some people accidentally use them (similar to how we already ignore for `rgba()`). The only use of this function is currently in graph cards where alpha channel is always manually manipulated, so we don't want it. If some other use comes up in the future, we could modify the function with an optional parameter to keep or toss the alpha. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24592
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
