### PR TITLE
Show hide create option in todo card editor

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-todo-list-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-todo-list-editor.ts
@@ -50,6 +50,7 @@ export class HuiTodoListEditor
         },
         { name: "theme", selector: { theme: {} } },
         { name: "hide_completed", selector: { boolean: {} } },
+        { name: "hide_create", selector: { boolean: {} } },
         {
           name: "display_order",
           selector: {
@@ -127,6 +128,7 @@ export class HuiTodoListEditor
           "ui.panel.lovelace.editor.card.config.optional"
         )})`;
       case "hide_completed":
+      case "hide_create":
       case "display_order":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.todo-list.${schema.name}`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7163,6 +7163,7 @@
               "description": "The To-do list card allows you to add, edit, check-off, and remove items from your to-do list.",
               "integration_not_loaded": "This card requires the `todo` integration to be set up.",
               "hide_completed": "Hide completed items",
+              "hide_create": "Hide 'Add item' field",
               "display_order": "Display Order",
               "sort_modes": {
                 "none": "Default",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add UI to enable the `hide_create` option in the [To-do list card](https://www.home-assistant.io/dashboards/todo-list/) editor. This makes possible to hide the input field without using YAML and makes this configuration option more visible to the user. 

![todo-card-editor-with-hide-create](https://github.com/user-attachments/assets/d1997081-ef9d-4809-ab4e-0d70cc4c71be)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
display_order: none
type: todo-list
entity: todo.shopping_list
hide_create: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/todo-list-card-without-add-item/638585/4
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
