### PR TITLE
Add shoelace z-index value

### DIFF
--- a/src/components/ha-tooltip.ts
+++ b/src/components/ha-tooltip.ts
@@ -29,7 +29,7 @@ export class HaTooltip extends SlTooltip {
         --sl-tooltip-padding: 8px;
         --sl-tooltip-border-radius: var(--ha-tooltip-border-radius, 4px);
         --sl-tooltip-arrow-size: var(--ha-tooltip-arrow-size, 8px);
-        --sl-z-index-tooltip: 1000;
+        --sl-z-index-tooltip: var(--ha-tooltip-z-index, 1000);
       }
     `,
   ];

--- a/src/components/ha-tooltip.ts
+++ b/src/components/ha-tooltip.ts
@@ -29,6 +29,7 @@ export class HaTooltip extends SlTooltip {
         --sl-tooltip-padding: 8px;
         --sl-tooltip-border-radius: var(--ha-tooltip-border-radius, 4px);
         --sl-tooltip-arrow-size: var(--ha-tooltip-arrow-size, 8px);
+        --sl-z-index-tooltip: 1000;
       }
     `,
   ];


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Since my HA was last updated, I can't see my love ones last location update, as can be seen in the following image:
![image](https://github.com/user-attachments/assets/3d87a432-ff39-49e2-a3f5-f63e20cb6c4f)
Apparently, as we moved to _shoelace_ tooltip and overridden their default styles, `--sl-z-index-tooltip` property wasn't overridden as well, resulting in an undefined z-index which makes it fall behind the map. This PR defines this variable again based on [_shoelace_'s default](https://shoelace.style/tokens/z-index) and fixes the issue.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24555 #24556
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
