### PR TITLE
Fix hui-energy-compare-card

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-compare-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-compare-card.ts
@@ -37,7 +37,7 @@ export class HuiEnergyCompareCard
   // Energy compare card cannot tolerate being removed from the DOM by hui-card,
   // as it calculates its own visibility and needs an active collection
   // subscription to do so.
-  disconnectOnHide = false;
+  connectedWhileHidden = true;
 
   public getCardSize(): Promise<number> | number {
     return 1;

--- a/src/panels/lovelace/cards/energy/hui-energy-compare-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-compare-card.ts
@@ -12,6 +12,7 @@ import type { LovelaceCard } from "../../types";
 import type { EnergyCardBaseConfig } from "../types";
 import { hasConfigChanged } from "../../common/has-changed";
 import "../../../../components/ha-alert";
+import { fireEvent } from "../../../../common/dom/fire_event";
 
 @customElement("hui-energy-compare-card")
 export class HuiEnergyCompareCard
@@ -32,6 +33,11 @@ export class HuiEnergyCompareCard
 
   // eslint-disable-next-line lit/no-native-attributes
   @property({ type: Boolean, reflect: true }) hidden = true;
+
+  // Energy compare card cannot tolerate being removed from the DOM by hui-card,
+  // as it calculates its own visibility and needs an active collection
+  // subscription to do so.
+  disconnectOnHide = false;
 
   public getCardSize(): Promise<number> | number {
     return 1;
@@ -106,7 +112,11 @@ export class HuiEnergyCompareCard
     this._end = data.end;
     this._startCompare = data.startCompare;
     this._endCompare = data.endCompare;
+    const oldHidden = this.hidden;
     this.hidden = !this._startCompare;
+    if (oldHidden !== this.hidden) {
+      fireEvent(this, "card-visibility-changed");
+    }
   }
 
   private _stopCompare(): void {

--- a/src/panels/lovelace/cards/hui-card.ts
+++ b/src/panels/lovelace/cards/hui-card.ts
@@ -270,7 +270,7 @@ export class HuiCard extends ReactiveElement {
       fireEvent(this, "card-visibility-changed", { value: visible });
     }
 
-    if (this._element.disconnectOnHide === false) {
+    if (this._element.connectedWhileHidden === true) {
       if (!this._element.parentElement) {
         this.appendChild(this._element);
       }

--- a/src/panels/lovelace/cards/hui-card.ts
+++ b/src/panels/lovelace/cards/hui-card.ts
@@ -270,7 +270,11 @@ export class HuiCard extends ReactiveElement {
       fireEvent(this, "card-visibility-changed", { value: visible });
     }
 
-    if (!visible && this._element.parentElement) {
+    if (this._element.disconnectOnHide === false) {
+      if (!this._element.parentElement) {
+        this.appendChild(this._element);
+      }
+    } else if (!visible && this._element.parentElement) {
       this.removeChild(this._element);
     } else if (visible && !this._element.parentElement) {
       this.appendChild(this._element);

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -65,6 +65,7 @@ export interface LovelaceCard extends HTMLElement {
   hass?: HomeAssistant;
   preview?: boolean;
   layout?: string;
+  disconnectOnHide?: boolean;
   getCardSize(): number | Promise<number>;
   /** @deprecated Use `getGridOptions` instead */
   getLayoutOptions?(): LovelaceLayoutOptions;

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -65,7 +65,7 @@ export interface LovelaceCard extends HTMLElement {
   hass?: HomeAssistant;
   preview?: boolean;
   layout?: string;
-  disconnectOnHide?: boolean;
+  connectedWhileHidden?: boolean;
   getCardSize(): number | Promise<number>;
   /** @deprecated Use `getGridOptions` instead */
   getLayoutOptions?(): LovelaceLayoutOptions;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fix #24704. Change feels kinda hacky to me, but I couldn't think of any cleaner solution.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
