### PR TITLE
Process expandable initial data also for none required expandables

### DIFF
--- a/src/components/ha-form/compute-initial-ha-form-data.ts
+++ b/src/components/ha-form/compute-initial-ha-form-data.ts
@@ -13,6 +13,8 @@ export const computeInitialHaFormData = (
       data[field.name] = field.description.suggested_value;
     } else if ("default" in field) {
       data[field.name] = field.default;
+    } else if (field.type === "expandable") {
+      data[field.name] = computeInitialHaFormData(field.schema);
     } else if (!field.required) {
       // Do nothing.
     } else if (field.type === "boolean") {
@@ -36,8 +38,6 @@ export const computeInitialHaFormData = (
         minutes: 0,
         seconds: 0,
       };
-    } else if (field.type === "expandable") {
-      data[field.name] = computeInitialHaFormData(field.schema);
     } else if ("selector" in field) {
       const selector: Selector = field.selector;
 

--- a/src/components/ha-form/compute-initial-ha-form-data.ts
+++ b/src/components/ha-form/compute-initial-ha-form-data.ts
@@ -14,7 +14,11 @@ export const computeInitialHaFormData = (
     } else if ("default" in field) {
       data[field.name] = field.default;
     } else if (field.type === "expandable") {
-      data[field.name] = computeInitialHaFormData(field.schema);
+      const expandableData = computeInitialHaFormData(field.schema);
+      if (field.required || Object.keys(expandableData).length) {
+        // Only add expandable data if it's required or any of its children have initial values.
+        data[field.name] = expandableData;
+      }
     } else if (!field.required) {
       // Do nothing.
     } else if (field.type === "boolean") {

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -144,17 +144,24 @@ class StepFlowForm extends LitElement {
   private async _submitStep(): Promise<void> {
     const stepData = this._stepData || {};
 
+    const checkAllRequiredFields = (
+      schema: readonly HaFormSchema[],
+      data: Record<string, any>
+    ) =>
+      schema.every(
+        (field) =>
+          (!field.required || !["", undefined].includes(data[field.name])) &&
+          (field.type !== "expandable" ||
+            (!field.required && data[field.name] === undefined) ||
+            checkAllRequiredFields(field.schema, data[field.name]))
+      );
+
     const allRequiredInfoFilledIn =
       stepData === undefined
         ? // If no data filled in, just check that any field is required
           this.step.data_schema.find((field) => field.required) === undefined
         : // If data is filled in, make sure all required fields are
-          stepData &&
-          this.step.data_schema.every(
-            (field) =>
-              !field.required ||
-              !["", undefined].includes(stepData![field.name])
-          );
+          checkAllRequiredFields(this.step.data_schema, stepData);
 
     if (!allRequiredInfoFilledIn) {
       this._errorMsg = this.hass.localize(


### PR DESCRIPTION


## Proposed change

The fields inside an expandable could also have suggested_value, default or even required fields, even if the expandable is not required.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
