### PR TITLE
Allow passing data as template in devtools/action

### DIFF
--- a/src/panels/developer-tools/action/developer-tools-action.ts
+++ b/src/panels/developer-tools/action/developer-tools-action.ts
@@ -9,7 +9,7 @@ import memoizeOne from "memoize-one";
 import { storage } from "../../../common/decorators/storage";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeObjectId } from "../../../common/entity/compute_object_id";
-import { hasTemplate } from "../../../common/string/has-template";
+import { hasTemplate, isTemplate } from "../../../common/string/has-template";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import { extractSearchParam } from "../../../common/url/search-params";
 import { copyToClipboard } from "../../../common/util/copy-clipboard";
@@ -349,8 +349,11 @@ class HaPanelDevAction extends LitElement {
         `ui.panel.developer-tools.tabs.actions.errors.${errorCategory}.invalid_action`
       );
     }
+    const dataIsTemplate =
+      typeof serviceData.data === "string" && isTemplate(serviceData.data);
     if (
       target &&
+      !dataIsTemplate &&
       !serviceData.target &&
       !serviceData.data?.entity_id &&
       !serviceData.data?.device_id &&
@@ -363,6 +366,7 @@ class HaPanelDevAction extends LitElement {
     for (const field of fields) {
       if (
         field.required &&
+        !dataIsTemplate &&
         (!serviceData.data || serviceData.data[field.key] === undefined)
       ) {
         return localize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
If trying to template the entire data object in developer-tools/action, the frontend would block the request complaining that you haven't defined the required fields, even though they might be provided by the template. 

E.g. this is a valid action call that was previously disallowed. 

```
action: input_text.set_value
data: >
  {{ {'value' : '.12345', 'entity_id': 'input_text.text1'} }}
```


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
