### PR TITLE
Show cameras on 2 rows in areas strategy

### DIFF
--- a/src/panels/lovelace/strategies/areas/helpers/areas-strategy-helper.ts
+++ b/src/panels/lovelace/strategies/areas/helpers/areas-strategy-helper.ts
@@ -210,8 +210,18 @@ export const computeAreaTileCardConfig =
     const additionalCardConfig: Partial<TileCardConfig> = {};
 
     const domain = computeDomain(entity);
+
     if (domain === "camera") {
-      additionalCardConfig.show_entity_picture = true;
+      return {
+        type: "picture-entity",
+        entity: entity,
+        show_state: false,
+        show_name: false,
+        grid_options: {
+          columns: 6,
+          rows: 2,
+        },
+      };
     }
 
     let feature: LovelaceCardFeatureConfig | undefined;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Currently, the areas overview strategy show cameras as a tile card. This makes it impossible to see what's going on nor does it allow people to use the picture to recognize which camera is which.

<img width="263" alt="image" src="https://github.com/user-attachments/assets/4bfa321e-f6fa-4282-ae14-509668a3b169" />

With this PR, a picture entity card is used for cameras and it takes up 2 rows.

On most narrow column width:

<img width="340" alt="image" src="https://github.com/user-attachments/assets/63f04ada-f0c3-44f7-89c6-0c50204430f3" />

On most wide column width:

<img width="525" alt="image" src="https://github.com/user-attachments/assets/0b69883d-71c4-4765-8d06-e41c94c6e667" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
