### PR TITLE
Add hidden "entity_id" column to "Settings -> Automations"

### DIFF
--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -114,7 +114,6 @@ import { showLabelDetailDialog } from "../labels/show-dialog-label-detail";
 import { showNewAutomationDialog } from "./show-dialog-new-automation";
 
 type AutomationItem = AutomationEntity & {
-  entity_id: string;
   name: string;
   area: string | undefined;
   last_triggered?: string | undefined;
@@ -232,7 +231,6 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         const labels = labelReg && entityRegEntry?.labels;
         return {
           ...automation,
-          entity_id: automation.entity_id,
           name: computeStateName(automation),
           area: entityRegEntry?.area_id
             ? areas[entityRegEntry?.area_id]?.name

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -114,6 +114,7 @@ import { showLabelDetailDialog } from "../labels/show-dialog-label-detail";
 import { showNewAutomationDialog } from "./show-dialog-new-automation";
 
 type AutomationItem = AutomationEntity & {
+  entity_id: string;
   name: string;
   area: string | undefined;
   last_triggered?: string | undefined;
@@ -231,6 +232,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         const labels = labelReg && entityRegEntry?.labels;
         return {
           ...automation,
+          entity_id: automation.entity_id,
           name: computeStateName(automation),
           area: entityRegEntry?.area_id
             ? areas[entityRegEntry?.area_id]?.name
@@ -273,6 +275,11 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
                     : "unset",
               })}
             ></ha-state-icon>`,
+        },
+        entity_id: {
+          title: "",
+          hidden: true,
+          filterable: true,
         },
         name: {
           title: localize("ui.panel.config.automation.picker.headers.name"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add a possibility to search/filter automations by `entity_id`.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/14874
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
