### PR TITLE
Add translation field mappings to Data Entry Flow forms

### DIFF
--- a/src/data/data_entry_flow.ts
+++ b/src/data/data_entry_flow.ts
@@ -27,6 +27,11 @@ export interface DataEntryFlowProgress {
   };
 }
 
+export interface TranslationFieldMapping {
+  translation_key: string;
+  description_placeholders?: Record<string, string>;
+}
+
 export interface DataEntryFlowStepForm {
   type: "form";
   flow_id: string;
@@ -37,6 +42,7 @@ export interface DataEntryFlowStepForm {
   description_placeholders?: Record<string, string>;
   last_step: boolean | null;
   preview?: string;
+  translation_field_mappings?: Record<string, TranslationFieldMapping>;
   translation_domain?: string;
 }
 
@@ -108,3 +114,20 @@ export const subscribeDataEntryFlowProgressed = (
     callback,
     "data_entry_flow_progressed"
   );
+
+export const getTranslationFieldKey = (
+  key: string,
+  step: DataEntryFlowStepForm,
+): string =>
+  step.translation_field_mappings?.[key]?.translation_key ?? key;
+
+export const getTranslationFieldMergedPlaceholders = (
+  key: string,
+  step: DataEntryFlowStepForm,
+): Record<string, string> => {
+  return {
+    ...step.description_placeholders ?? {},
+    ...step.translation_field_mappings?.[key]?.description_placeholders ?? {}
+  };
+}
+

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -11,6 +11,7 @@ import {
   loadDataEntryFlowDialog,
   showFlowDialog,
 } from "./show-dialog-data-entry-flow";
+import { getTranslationFieldMergedPlaceholders, getTranslationFieldKey } from "../../data/data_entry_flow";
 
 export const loadConfigFlowDialog = loadDataEntryFlowDialog;
 
@@ -79,33 +80,46 @@ export const showConfigFlowDialog = (
     },
 
     renderShowFormStepFieldLabel(hass, step, field, options) {
+      const fieldKey = getTranslationFieldKey(field.name, step);
+      const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        field.name,
+        step);
+
       if (field.type === "expandable") {
         return hass.localize(
-          `component.${step.handler}.config.step.${step.step_id}.sections.${field.name}.name`
-        );
+          `component.${step.handler}.config.step.${step.step_id}.sections.${fieldKey}.name`,
+          merged_placeholders
+        ) || field.name;
       }
 
-      const prefix = options?.path?.[0] ? `sections.${options.path[0]}.` : "";
+      const prefix = options?.path?.[0] ? `sections.${getTranslationFieldKey(options.path[0], step)}.` : "";
 
       return (
         hass.localize(
-          `component.${step.handler}.config.step.${step.step_id}.${prefix}data.${field.name}`
+          `component.${step.handler}.config.step.${step.step_id}.${prefix}data.${fieldKey}`,
+          merged_placeholders
         ) || field.name
       );
     },
 
     renderShowFormStepFieldHelper(hass, step, field, options) {
+      const fieldKey = getTranslationFieldKey(field.name, step);
+      const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        field.name,
+        step);
+
       if (field.type === "expandable") {
         return hass.localize(
-          `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.sections.${field.name}.description`
+          `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.sections.${fieldKey}.description`,
+          merged_placeholders
         );
       }
 
-      const prefix = options?.path?.[0] ? `sections.${options.path[0]}.` : "";
+      const prefix = options?.path?.[0] ? `sections.${getTranslationFieldKey(options.path[0], step)}.` : "";
 
       const description = hass.localize(
-        `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.${prefix}data_description.${field.name}`,
-        step.description_placeholders
+        `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.${prefix}data_description.${fieldKey}`,
+        merged_placeholders
       );
 
       return description
@@ -114,16 +128,26 @@ export const showConfigFlowDialog = (
     },
 
     renderShowFormStepFieldError(hass, step, error) {
+      const errorKey = getTranslationFieldKey(error, step);
+      const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        error,
+        step);
+
       return (
         hass.localize(
-          `component.${step.translation_domain || step.translation_domain || step.handler}.config.error.${error}`,
-          step.description_placeholders
+          `component.${step.translation_domain || step.translation_domain || step.handler}.config.error.${errorKey}`,
+          merged_placeholders
         ) || error
       );
     },
 
     renderShowFormStepFieldLocalizeValue(hass, step, key) {
-      return hass.localize(`component.${step.handler}.selector.${key}`);
+      const valueKey = getTranslationFieldKey(key, step);
+      const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        key,
+        step);
+
+      return hass.localize(`component.${step.handler}.selector.${valueKey}`, merged_placeholders);
     },
 
     renderShowFormStepSubmitButton(hass, step) {
@@ -132,8 +156,7 @@ export const showConfigFlowDialog = (
           `component.${step.handler}.config.step.${step.step_id}.submit`
         ) ||
         hass.localize(
-          `ui.panel.config.integrations.config_flow.${
-            step.last_step === false ? "next" : "submit"
+          `ui.panel.config.integrations.config_flow.${step.last_step === false ? "next" : "submit"
           }`
         )
       );
@@ -159,8 +182,8 @@ export const showConfigFlowDialog = (
       return html`
         <p>
           ${hass.localize(
-            "ui.panel.config.integrations.config_flow.external_step.description"
-          )}
+        "ui.panel.config.integrations.config_flow.external_step.description"
+      )}
         </p>
         ${description
           ? html`
@@ -176,8 +199,7 @@ export const showConfigFlowDialog = (
 
     renderCreateEntryDescription(hass, step) {
       const description = hass.localize(
-        `component.${step.translation_domain || step.handler}.config.create_entry.${
-          step.description || "default"
+        `component.${step.translation_domain || step.handler}.config.create_entry.${step.description || "default"
         }`,
         step.description_placeholders
       );
@@ -259,9 +281,9 @@ export const showConfigFlowDialog = (
           integration: domain
             ? domainToName(hass.localize, domain)
             : // when we are continuing a config flow, we only know the ID and not the domain
-              hass.localize(
-                "ui.panel.config.integrations.config_flow.loading.fallback_title"
-              ),
+            hass.localize(
+              "ui.panel.config.integrations.config_flow.loading.fallback_title"
+            ),
         }
       );
     },

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -12,6 +12,7 @@ import {
   loadDataEntryFlowDialog,
   showFlowDialog,
 } from "./show-dialog-data-entry-flow";
+import { getTranslationFieldKey, getTranslationFieldMergedPlaceholders } from "../../data/data_entry_flow";
 
 export const loadOptionsFlowDialog = loadDataEntryFlowDialog;
 
@@ -94,33 +95,46 @@ export const showOptionsFlowDialog = (
       },
 
       renderShowFormStepFieldLabel(hass, step, field, options) {
+        const fieldKey = getTranslationFieldKey(field.name, step);
+        const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        field.name,
+        step);
+        
         if (field.type === "expandable") {
           return hass.localize(
-            `component.${configEntry.domain}.options.step.${step.step_id}.sections.${field.name}.name`
+            `component.${configEntry.domain}.options.step.${step.step_id}.sections.${fieldKey}.name`,
+            merged_placeholders
           );
         }
 
-        const prefix = options?.path?.[0] ? `sections.${options.path[0]}.` : "";
+        const prefix = options?.path?.[0] ? `sections.${getTranslationFieldKey(options.path[0], step)}.` : "";
 
         return (
           hass.localize(
-            `component.${configEntry.domain}.options.step.${step.step_id}.${prefix}data.${field.name}`
+            `component.${configEntry.domain}.options.step.${step.step_id}.${prefix}data.${fieldKey}`,
+            merged_placeholders
           ) || field.name
         );
       },
 
       renderShowFormStepFieldHelper(hass, step, field, options) {
+        const fieldKey = getTranslationFieldKey(field.name, step);
+        const merged_placeholders = getTranslationFieldMergedPlaceholders(
+            field.name,
+            step);
+
         if (field.type === "expandable") {
           return hass.localize(
-            `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.sections.${field.name}.description`
+            `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.sections.${fieldKey}.description`,
+            merged_placeholders
           );
         }
 
-        const prefix = options?.path?.[0] ? `sections.${options.path[0]}.` : "";
+        const prefix = options?.path?.[0] ? `sections.${getTranslationFieldKey(options.path[0], step)}.` : "";
 
         const description = hass.localize(
-          `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.${prefix}data_description.${field.name}`,
-          step.description_placeholders
+          `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.${prefix}data_description.${fieldKey}`,
+          merged_placeholders
         );
         return description
           ? html`<ha-markdown breaks .content=${description}></ha-markdown>`
@@ -128,16 +142,26 @@ export const showOptionsFlowDialog = (
       },
 
       renderShowFormStepFieldError(hass, step, error) {
+        const errorKey = getTranslationFieldKey(error, step);
+        const merged_placeholders = getTranslationFieldMergedPlaceholders(
+            error,
+            step);
+
         return (
           hass.localize(
-            `component.${step.translation_domain || configEntry.domain}.options.error.${error}`,
-            step.description_placeholders
+            `component.${step.translation_domain || configEntry.domain}.options.error.${errorKey}`,
+            merged_placeholders
           ) || error
         );
       },
 
-      renderShowFormStepFieldLocalizeValue(hass, _step, key) {
-        return hass.localize(`component.${configEntry.domain}.selector.${key}`);
+      renderShowFormStepFieldLocalizeValue(hass, step, key) {
+        const valueKey = getTranslationFieldKey(key, step);
+        const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        key,
+        step);
+
+        return hass.localize(`component.${configEntry.domain}.selector.${valueKey}`, merged_placeholders);
       },
 
       renderShowFormStepSubmitButton(hass, step) {

--- a/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
@@ -12,6 +12,7 @@ import {
   loadDataEntryFlowDialog,
   showFlowDialog,
 } from "./show-dialog-data-entry-flow";
+import { getTranslationFieldMergedPlaceholders, getTranslationFieldKey } from "../../data/data_entry_flow";
 
 export const loadSubConfigFlowDialog = loadDataEntryFlowDialog;
 
@@ -85,33 +86,46 @@ export const showSubConfigFlowDialog = (
     },
 
     renderShowFormStepFieldLabel(hass, step, field, options) {
+      const fieldKey = getTranslationFieldKey(field.name, step);
+      const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        field.name,
+        step);
+    
       if (field.type === "expandable") {
         return hass.localize(
-          `component.${configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.sections.${field.name}.name`
-        );
+          `component.${configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.sections.${fieldKey}.name`,
+          merged_placeholders
+        ) || field.name;
       }
 
-      const prefix = options?.path?.[0] ? `sections.${options.path[0]}.` : "";
+      const prefix = options?.path?.[0] ? `sections.${getTranslationFieldKey(options.path[0], step)}.` : "";
 
       return (
         hass.localize(
-          `component.${configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.${prefix}data.${field.name}`
+          `component.${configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.${prefix}data.${fieldKey}`,
+          merged_placeholders
         ) || field.name
       );
     },
 
     renderShowFormStepFieldHelper(hass, step, field, options) {
+      const fieldKey = getTranslationFieldKey(field.name, step);
+      const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        field.name,
+        step);
+
       if (field.type === "expandable") {
         return hass.localize(
-          `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.sections.${field.name}.description`
+          `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.sections.${fieldKey}.description`,
+          merged_placeholders
         );
       }
 
-      const prefix = options?.path?.[0] ? `sections.${options.path[0]}.` : "";
+      const prefix = options?.path?.[0] ? `sections.${getTranslationFieldKey(options.path[0], step)}.` : "";
 
       const description = hass.localize(
-        `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.${prefix}data_description.${field.name}`,
-        step.description_placeholders
+        `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.${prefix}data_description.${fieldKey}`,
+        merged_placeholders
       );
 
       return description
@@ -120,16 +134,26 @@ export const showSubConfigFlowDialog = (
     },
 
     renderShowFormStepFieldError(hass, step, error) {
+      const errorKey = getTranslationFieldKey(error, step);
+      const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        error,
+        step);
+
       return (
         hass.localize(
-          `component.${step.translation_domain || step.translation_domain || configEntry.domain}.config_subentries.${flowType}.error.${error}`,
-          step.description_placeholders
+          `component.${step.translation_domain || step.translation_domain || configEntry.domain}.config_subentries.${flowType}.error.${errorKey}`,
+          merged_placeholders
         ) || error
       );
     },
 
-    renderShowFormStepFieldLocalizeValue(hass, _step, key) {
-      return hass.localize(`component.${configEntry.domain}.selector.${key}`);
+    renderShowFormStepFieldLocalizeValue(hass, step, key) {
+      const valueKey = getTranslationFieldKey(key, step);
+      const merged_placeholders = getTranslationFieldMergedPlaceholders(
+        key,
+        step);
+        
+      return hass.localize(`component.${configEntry.domain}.selector.${valueKey}`, merged_placeholders);
     },
 
     renderShowFormStepSubmitButton(hass, step) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Provide a way to translate dynamic fields/sections in the form `data_schema` of Config / Options / Subentry flows.

_[Reusing the documentation from the related documentation PR]_
Add a `translation_field_mappings` dictionary to map each dynamic field key to its corresponding translation key `translation_key` and its specific translation placeholders `description_placeholders` if needed.

These specific placeholders are used only within these specific field translation strings and for this dynamic field key, allowing different values to be used for each dynamic field. They are merged with the `description_placeholders` form placeholders and take precedence in case of conflict.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
N/A

Example code is available in the related Core PR.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion:
  - an old PR implementing a way to translate dynamic fields in form data_schema: #4195
  -  an issue feature request: https://github.com/home-assistant/core/issues/92619
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2619
- Link to core pull request: https://github.com/home-assistant/core/pull/141346

This feature has already been asked a few times in the past and I think it can be really useful to add dynamic content to forms and provide better config flow.

Unlike the old PR that implemented dynamic labels, this one should cover more use cases of dynamic field translation (labels and helpers for fields and sections, errors, etc.) while still keeping the translations centralized in the dedicated files.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
