### PR TITLE
Move compatibility to static polyfill handling

### DIFF
--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -30,13 +30,13 @@ module.exports.emptyPackages = ({ isHassioBuild }) =>
     require.resolve("@vaadin/vaadin-material-styles/font-icons.js"),
     // Icons in supervisor conflict with icons in HA so we don't load.
     isHassioBuild &&
-    require.resolve(
-      path.resolve(paths.polymer_dir, "src/components/ha-icon.ts")
-    ),
+      require.resolve(
+        path.resolve(paths.polymer_dir, "src/components/ha-icon.ts")
+      ),
     isHassioBuild &&
-    require.resolve(
-      path.resolve(paths.polymer_dir, "src/components/ha-icon-picker.ts")
-    ),
+      require.resolve(
+        path.resolve(paths.polymer_dir, "src/components/ha-icon-picker.ts")
+      ),
   ].filter(Boolean);
 
 module.exports.definedVars = ({ isProdBuild, latestBuild, defineOverlay }) => ({
@@ -47,10 +47,11 @@ module.exports.definedVars = ({ isProdBuild, latestBuild, defineOverlay }) => ({
   __SUPERVISOR__: false,
   __BACKWARDS_COMPAT__: false,
   __STATIC_PATH__: "/static/",
-  __HASS_URL__: `\`${"HASS_URL" in process.env
+  __HASS_URL__: `\`${
+    "HASS_URL" in process.env
       ? process.env.HASS_URL
       : "${location.protocol}//${location.host}"
-    }\``,
+  }\``,
   "process.env.NODE_ENV": JSON.stringify(
     isProdBuild ? "production" : "development"
   ),
@@ -225,9 +226,9 @@ module.exports.config = {
       entry: {
         "service-worker": !latestBuild
           ? {
-            import: "./src/entrypoints/service-worker.ts",
-            layer: "sw",
-          }
+              import: "./src/entrypoints/service-worker.ts",
+              layer: "sw",
+            }
           : "./src/entrypoints/service-worker.ts",
         app: "./src/entrypoints/app.ts",
         authorize: "./src/entrypoints/authorize.ts",

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -18,7 +18,7 @@ module.exports.sourceMapURL = () => {
 module.exports.ignorePackages = () => [];
 
 // Files from NPM packages that we should replace with empty file
-module.exports.emptyPackages = ({ latestBuild, isHassioBuild }) =>
+module.exports.emptyPackages = ({ isHassioBuild }) =>
   [
     // Contains all color definitions for all material color sets.
     // We don't use it
@@ -28,21 +28,15 @@ module.exports.emptyPackages = ({ latestBuild, isHassioBuild }) =>
     require.resolve("@polymer/font-roboto/roboto.js"),
     require.resolve("@vaadin/vaadin-material-styles/typography.js"),
     require.resolve("@vaadin/vaadin-material-styles/font-icons.js"),
-    // Compatibility not needed for latest builds
-    latestBuild &&
-      // wrapped in require.resolve so it blows up if file no longer exists
-      require.resolve(
-        path.resolve(paths.polymer_dir, "src/resources/compatibility.ts")
-      ),
     // Icons in supervisor conflict with icons in HA so we don't load.
     isHassioBuild &&
-      require.resolve(
-        path.resolve(paths.polymer_dir, "src/components/ha-icon.ts")
-      ),
+    require.resolve(
+      path.resolve(paths.polymer_dir, "src/components/ha-icon.ts")
+    ),
     isHassioBuild &&
-      require.resolve(
-        path.resolve(paths.polymer_dir, "src/components/ha-icon-picker.ts")
-      ),
+    require.resolve(
+      path.resolve(paths.polymer_dir, "src/components/ha-icon-picker.ts")
+    ),
   ].filter(Boolean);
 
 module.exports.definedVars = ({ isProdBuild, latestBuild, defineOverlay }) => ({
@@ -53,11 +47,10 @@ module.exports.definedVars = ({ isProdBuild, latestBuild, defineOverlay }) => ({
   __SUPERVISOR__: false,
   __BACKWARDS_COMPAT__: false,
   __STATIC_PATH__: "/static/",
-  __HASS_URL__: `\`${
-    "HASS_URL" in process.env
+  __HASS_URL__: `\`${"HASS_URL" in process.env
       ? process.env.HASS_URL
       : "${location.protocol}//${location.host}"
-  }\``,
+    }\``,
   "process.env.NODE_ENV": JSON.stringify(
     isProdBuild ? "production" : "development"
   ),
@@ -232,9 +225,9 @@ module.exports.config = {
       entry: {
         "service-worker": !latestBuild
           ? {
-              import: "./src/entrypoints/service-worker.ts",
-              layer: "sw",
-            }
+            import: "./src/entrypoints/service-worker.ts",
+            layer: "sw",
+          }
           : "./src/entrypoints/service-worker.ts",
         app: "./src/entrypoints/app.ts",
         authorize: "./src/entrypoints/authorize.ts",

--- a/build-scripts/gulp/gather-static.js
+++ b/build-scripts/gulp/gather-static.js
@@ -14,8 +14,8 @@ const copyFileDir = (fromFile, toDir) =>
 
 const genStaticPath =
   (staticDir) =>
-    (...parts) =>
-      path.resolve(staticDir, ...parts);
+  (...parts) =>
+    path.resolve(staticDir, ...parts);
 
 function copyTranslations(staticDir) {
   const staticPath = genStaticPath(staticDir);
@@ -60,7 +60,10 @@ function copyPolyfills(staticDir) {
     staticPath("polyfills/")
   );
   // Lit polyfill support
-  fs.copySync(npmPath("lit/polyfill-support.js"), path.join(staticPath("polyfills/"), "lit-polyfill-support.js"));
+  fs.copySync(
+    npmPath("lit/polyfill-support.js"),
+    path.join(staticPath("polyfills/"), "lit-polyfill-support.js")
+  );
 
   // dialog-polyfill css
   copyFileDir(

--- a/build-scripts/gulp/gather-static.js
+++ b/build-scripts/gulp/gather-static.js
@@ -14,8 +14,8 @@ const copyFileDir = (fromFile, toDir) =>
 
 const genStaticPath =
   (staticDir) =>
-  (...parts) =>
-    path.resolve(staticDir, ...parts);
+    (...parts) =>
+      path.resolve(staticDir, ...parts);
 
 function copyTranslations(staticDir) {
   const staticPath = genStaticPath(staticDir);
@@ -59,6 +59,8 @@ function copyPolyfills(staticDir) {
     npmPath("@webcomponents/webcomponentsjs/webcomponents-bundle.js.map"),
     staticPath("polyfills/")
   );
+  // Lit polyfill support
+  fs.copySync(npmPath("lit/polyfill-support.js"), path.join(staticPath("polyfills/"), "lit-polyfill-support.js"));
 
   // dialog-polyfill css
   copyFileDir(

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -101,16 +101,16 @@ const createRspackConfig = ({
         // external chunks are broken for:
         chunks: !isProdBuild
           ? // improve incremental build speed, but blows up bundle size
-          new RegExp(
-            `^(?!(${Object.keys(entry).join("|")}|.*work(?:er|let))$)`
-          )
+            new RegExp(
+              `^(?!(${Object.keys(entry).join("|")}|.*work(?:er|let))$)`
+            )
           : // - ESM output: https://github.com/webpack/webpack/issues/17014
-          // - Worklets use `importScripts`: https://github.com/webpack/webpack/issues/11543
-          (chunk) =>
-            !chunk.canBeInitial() &&
-            !new RegExp(
-              `^.+-work${latestBuild ? "(?:let|er)" : "let"}$`
-            ).test(chunk.name),
+            // - Worklets use `importScripts`: https://github.com/webpack/webpack/issues/11543
+            (chunk) =>
+              !chunk.canBeInitial() &&
+              !new RegExp(
+                `^.+-work${latestBuild ? "(?:let|er)" : "let"}$`
+              ).test(chunk.name),
       },
     },
     plugins: [
@@ -155,30 +155,28 @@ const createRspackConfig = ({
         },
       }),
       new rspack.NormalModuleReplacementPlugin(
-        new RegExp(
-          bundle.emptyPackages({ isHassioBuild }).join("|")
-        ),
+        new RegExp(bundle.emptyPackages({ isHassioBuild }).join("|")),
         path.resolve(paths.polymer_dir, "src/util/empty.js")
       ),
       !isProdBuild && new LogStartCompilePlugin(),
       isProdBuild &&
-      new StatsWriterPlugin({
-        filename: path.relative(
-          outputPath,
-          path.join(paths.build_dir, "stats", `${name}.json`)
-        ),
-        stats: { assets: true, chunks: true, modules: true },
-        transform: (stats) => JSON.stringify(filterStats(stats)),
-      }),
+        new StatsWriterPlugin({
+          filename: path.relative(
+            outputPath,
+            path.join(paths.build_dir, "stats", `${name}.json`)
+          ),
+          stats: { assets: true, chunks: true, modules: true },
+          transform: (stats) => JSON.stringify(filterStats(stats)),
+        }),
       isProdBuild &&
-      isStatsBuild &&
-      new RsdoctorRspackPlugin({
-        reportDir: path.join(paths.build_dir, "rsdoctor"),
-        features: ["plugins", "bundle"],
-        supports: {
-          generateTileGraph: true,
-        },
-      }),
+        isStatsBuild &&
+        new RsdoctorRspackPlugin({
+          reportDir: path.join(paths.build_dir, "rsdoctor"),
+          features: ["plugins", "bundle"],
+          supports: {
+            generateTileGraph: true,
+          },
+        }),
     ].filter(Boolean),
     resolve: {
       extensions: [".ts", ".js", ".json"],
@@ -228,18 +226,18 @@ const createRspackConfig = ({
           `devtool${v}ModuleFilenameTemplate`,
           !isTestBuild && isProdBuild
             ? (info) => {
-              if (
-                !path.isAbsolute(info.absoluteResourcePath) ||
-                !existsSync(info.resourcePath) ||
-                info.resourcePath.startsWith("./node_modules")
-              ) {
-                // Source URLs are unknown for dependencies, so we use a relative URL with a
-                // non - existent top directory.  This results in a clean source tree in browser
-                // dev tools, and they stay happy getting 404s with valid requests.
-                return `/unknown${path.resolve("/", info.resourcePath)}`;
+                if (
+                  !path.isAbsolute(info.absoluteResourcePath) ||
+                  !existsSync(info.resourcePath) ||
+                  info.resourcePath.startsWith("./node_modules")
+                ) {
+                  // Source URLs are unknown for dependencies, so we use a relative URL with a
+                  // non - existent top directory.  This results in a clean source tree in browser
+                  // dev tools, and they stay happy getting 404s with valid requests.
+                  return `/unknown${path.resolve("/", info.resourcePath)}`;
+                }
+                return new URL(info.resourcePath, bundle.sourceMapURL()).href;
               }
-              return new URL(info.resourcePath, bundle.sourceMapURL()).href;
-            }
             : undefined,
         ])
       ),

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -101,16 +101,16 @@ const createRspackConfig = ({
         // external chunks are broken for:
         chunks: !isProdBuild
           ? // improve incremental build speed, but blows up bundle size
-            new RegExp(
-              `^(?!(${Object.keys(entry).join("|")}|.*work(?:er|let))$)`
-            )
+          new RegExp(
+            `^(?!(${Object.keys(entry).join("|")}|.*work(?:er|let))$)`
+          )
           : // - ESM output: https://github.com/webpack/webpack/issues/17014
-            // - Worklets use `importScripts`: https://github.com/webpack/webpack/issues/11543
-            (chunk) =>
-              !chunk.canBeInitial() &&
-              !new RegExp(
-                `^.+-work${latestBuild ? "(?:let|er)" : "let"}$`
-              ).test(chunk.name),
+          // - Worklets use `importScripts`: https://github.com/webpack/webpack/issues/11543
+          (chunk) =>
+            !chunk.canBeInitial() &&
+            !new RegExp(
+              `^.+-work${latestBuild ? "(?:let|er)" : "let"}$`
+            ).test(chunk.name),
       },
     },
     plugins: [
@@ -156,29 +156,29 @@ const createRspackConfig = ({
       }),
       new rspack.NormalModuleReplacementPlugin(
         new RegExp(
-          bundle.emptyPackages({ latestBuild, isHassioBuild }).join("|")
+          bundle.emptyPackages({ isHassioBuild }).join("|")
         ),
         path.resolve(paths.polymer_dir, "src/util/empty.js")
       ),
       !isProdBuild && new LogStartCompilePlugin(),
       isProdBuild &&
-        new StatsWriterPlugin({
-          filename: path.relative(
-            outputPath,
-            path.join(paths.build_dir, "stats", `${name}.json`)
-          ),
-          stats: { assets: true, chunks: true, modules: true },
-          transform: (stats) => JSON.stringify(filterStats(stats)),
-        }),
+      new StatsWriterPlugin({
+        filename: path.relative(
+          outputPath,
+          path.join(paths.build_dir, "stats", `${name}.json`)
+        ),
+        stats: { assets: true, chunks: true, modules: true },
+        transform: (stats) => JSON.stringify(filterStats(stats)),
+      }),
       isProdBuild &&
-        isStatsBuild &&
-        new RsdoctorRspackPlugin({
-          reportDir: path.join(paths.build_dir, "rsdoctor"),
-          features: ["plugins", "bundle"],
-          supports: {
-            generateTileGraph: true,
-          },
-        }),
+      isStatsBuild &&
+      new RsdoctorRspackPlugin({
+        reportDir: path.join(paths.build_dir, "rsdoctor"),
+        features: ["plugins", "bundle"],
+        supports: {
+          generateTileGraph: true,
+        },
+      }),
     ].filter(Boolean),
     resolve: {
       extensions: [".ts", ".js", ".json"],
@@ -228,18 +228,18 @@ const createRspackConfig = ({
           `devtool${v}ModuleFilenameTemplate`,
           !isTestBuild && isProdBuild
             ? (info) => {
-                if (
-                  !path.isAbsolute(info.absoluteResourcePath) ||
-                  !existsSync(info.resourcePath) ||
-                  info.resourcePath.startsWith("./node_modules")
-                ) {
-                  // Source URLs are unknown for dependencies, so we use a relative URL with a
-                  // non - existent top directory.  This results in a clean source tree in browser
-                  // dev tools, and they stay happy getting 404s with valid requests.
-                  return `/unknown${path.resolve("/", info.resourcePath)}`;
-                }
-                return new URL(info.resourcePath, bundle.sourceMapURL()).href;
+              if (
+                !path.isAbsolute(info.absoluteResourcePath) ||
+                !existsSync(info.resourcePath) ||
+                info.resourcePath.startsWith("./node_modules")
+              ) {
+                // Source URLs are unknown for dependencies, so we use a relative URL with a
+                // non - existent top directory.  This results in a clean source tree in browser
+                // dev tools, and they stay happy getting 404s with valid requests.
+                return `/unknown${path.resolve("/", info.resourcePath)}`;
               }
+              return new URL(info.resourcePath, bundle.sourceMapURL()).href;
+            }
             : undefined,
         ])
       ),

--- a/demo/src/ha-demo.ts
+++ b/demo/src/ha-demo.ts
@@ -1,5 +1,3 @@
-// Compat needs to be first import
-import "../../src/resources/compatibility";
 import { customElement } from "lit/decorators";
 import { isNavigationClick } from "../../src/common/dom/is-navigation-click";
 import { navigate } from "../../src/common/navigate";

--- a/hassio/src/entrypoint.ts
+++ b/hassio/src/entrypoint.ts
@@ -1,5 +1,3 @@
-// Compat needs to be first import
-import "../../src/resources/compatibility";
 import "./hassio-main";
 
 import("../../src/resources/ha-style");

--- a/src/common/feature-detect/support-web-components.ts
+++ b/src/common/feature-detect/support-web-components.ts
@@ -1,2 +1,1 @@
-export const webComponentsSupported =
-  "customElements" in window && "content" in document.createElement("template");
+export const webComponentsSupported = "attachShadow" in Element.prototype;

--- a/src/entrypoints/app.ts
+++ b/src/entrypoints/app.ts
@@ -1,5 +1,3 @@
-// Compat needs to be first import
-import "../resources/compatibility";
 import "@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min";
 import "../layouts/home-assistant";
 

--- a/src/entrypoints/authorize.ts
+++ b/src/entrypoints/authorize.ts
@@ -1,5 +1,3 @@
-// Compat needs to be first import
-import "../resources/compatibility";
 import "../auth/ha-authorize";
 
 import("../resources/ha-style");

--- a/src/entrypoints/custom-panel.ts
+++ b/src/entrypoints/custom-panel.ts
@@ -1,6 +1,3 @@
-// Compat needs to be first import
-import "../resources/compatibility";
-
 import type { CSSResult } from "lit";
 import { fireEvent } from "../common/dom/fire_event";
 import { isNavigationClick } from "../common/dom/is-navigation-click";
@@ -67,9 +64,10 @@ function initialize(
   let start: Promise<unknown> = Promise.resolve();
 
   if (!webComponentsSupported) {
-    start = start.then(() =>
-      loadJS(`${__STATIC_PATH__}polyfills/webcomponents-bundle.js`)
-    );
+    start = start.then(() => {
+      loadJS(`${__STATIC_PATH__}polyfills/webcomponents-bundle.js`);
+      loadJS(`${__STATIC_PATH__}polyfills/lit-polyfill-support.js`);
+    });
   }
 
   if (__BUILD__ === "legacy") {

--- a/src/entrypoints/onboarding.ts
+++ b/src/entrypoints/onboarding.ts
@@ -1,5 +1,3 @@
-// Compat needs to be first import
-import "../resources/compatibility";
 import "../onboarding/ha-onboarding";
 
 import("../resources/ha-style");

--- a/src/html/_js_base.html.template
+++ b/src/html/_js_base.html.template
@@ -8,13 +8,9 @@
     return document.head.appendChild(script);
   }
   window.polymerSkipLoadingFontRoboto = true;
-  if (
-    !(
-      "customElements" in window &&
-      "content" in document.createElement("template")
-    )
-  ) {
+  if (!("attachShadow" in Element.prototype)) {
     _ls("/static/polyfills/webcomponents-bundle.js", true);
+    _ls("/static/polyfills/lit-polyfill-support.js", true);
   }
   // Modern browsers are detected primarily using the user agent string.
   // A feature detection which roughly lines up with the modern targets is used

--- a/src/resources/compatibility.ts
+++ b/src/resources/compatibility.ts
@@ -1,2 +1,0 @@
-// Caution before editing - For latest builds, this module is replaced with emptiness and thus not imported (see build-scripts/bundle.js)
-import "lit/polyfill-support";


### PR DESCRIPTION



## Proposed change
This would be loaded too much, and was the only thing left in compatibility. Now together with webcomponents polyfill as it should.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
