### PR TITLE
Do not play pre-announce sound when testing voice on satellite

### DIFF
--- a/src/data/assist_satellite.ts
+++ b/src/data/assist_satellite.ts
@@ -49,9 +49,12 @@ export const testAssistSatelliteConnection = (
 export const assistSatelliteAnnounce = (
   hass: HomeAssistant,
   entity_id: string,
-  message: string
-) =>
-  hass.callService("assist_satellite", "announce", { message }, { entity_id });
+  args: {
+    message?: string;
+    media_id?: string;
+    preannounce_media_id?: string | null;
+  }
+) => hass.callService("assist_satellite", "announce", args, { entity_id });
 
 export const fetchAssistSatelliteConfiguration = (
   hass: HomeAssistant,

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-success.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-success.ts
@@ -246,7 +246,10 @@ export class HaVoiceAssistantSetupStepSuccess extends LitElement {
     if (!this.assistEntityId) {
       return;
     }
-    await assistSatelliteAnnounce(this.hass, this.assistEntityId, message);
+    await assistSatelliteAnnounce(this.hass, this.assistEntityId, {
+      message,
+      preannounce_media_id: null,
+    });
   }
 
   private _testWakeWord() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When testing voices at the end of the wizard, do not use the pre-announce sound.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
