### PR TITLE
Support entity-less tile card

### DIFF
--- a/src/panels/lovelace/cards/tile/badges/tile-badge.ts
+++ b/src/panels/lovelace/cards/tile/badges/tile-badge.ts
@@ -13,12 +13,12 @@ import "../../../../../components/tile/ha-tile-badge";
 import "../../../../../components/ha-svg-icon";
 
 export type RenderBadgeFunction = (
-  stateObj: HassEntity,
+  stateObj: HassEntity | undefined,
   hass: HomeAssistant
 ) => TemplateResult | typeof nothing;
 
 export const renderTileBadge: RenderBadgeFunction = (stateObj, hass) => {
-  if (stateObj.state === UNKNOWN) {
+  if (!stateObj || stateObj.state === UNKNOWN) {
     return nothing;
   }
   if (stateObj.state === UNAVAILABLE) {
@@ -32,7 +32,7 @@ export const renderTileBadge: RenderBadgeFunction = (stateObj, hass) => {
       </ha-tile-badge>
     `;
   }
-  const domain = computeDomain(stateObj.entity_id);
+  const domain = stateObj ? computeDomain(stateObj.entity_id) : undefined;
   switch (domain) {
     case "person":
     case "device_tracker":


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change makes the tile card not require an entity. This allows for custom buttons using the tile card, similar to the button card.

Currently, to do this, I use a dummy button helper, which works, but is hacky.

![image](https://github.com/user-attachments/assets/97d22d9b-ed87-46a8-8aa5-a414e9d1151f)

From my testing, everything is working as expected. The state fields in the editor don't do anything (which matches the behavior of the button card, which also shows useless state fields). The color field is also useless, although I think it would be useful to have the state color apply by default when there's no entity selected (since there's no active state for entity-less tiles).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
icon: mdi:thermostat
tap_action:
  action: navigate
  navigation_path: /lovelace/climate
name: Climate

```


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/38341

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
