### PR TITLE
Restore default hold action for some cards

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -106,6 +106,7 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
 
     this._config = {
       tap_action: { action: "more-info" },
+      hold_action: { action: "more-info" },
       ...config,
     };
   }

--- a/src/panels/lovelace/editor/config-elements/elements/hui-icon-element-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/elements/hui-icon-element-editor.ts
@@ -40,19 +40,27 @@ const SCHEMA = [
         },
       },
       {
+        name: "hold_action",
+        selector: {
+          ui_action: {
+            default_action: "more-info",
+          },
+        },
+      },
+      {
         name: "",
         type: "optional_actions",
         flatten: true,
-        schema: (["hold_action", "double_tap_action"] as const).map(
-          (action) => ({
-            name: action,
+        schema: [
+          {
+            name: "double_tap_action",
             selector: {
               ui_action: {
-                default_action: "none" as const,
+                default_action: "none",
               },
             },
-          })
-        ),
+          },
+        ],
       },
     ],
   },

--- a/src/panels/lovelace/editor/config-elements/elements/hui-image-element-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/elements/hui-image-element-editor.ts
@@ -45,19 +45,27 @@ const SCHEMA = [
         },
       },
       {
+        name: "hold_action",
+        selector: {
+          ui_action: {
+            default_action: "more-info",
+          },
+        },
+      },
+      {
         name: "",
         type: "optional_actions",
         flatten: true,
-        schema: (["hold_action", "double_tap_action"] as const).map(
-          (action) => ({
-            name: action,
+        schema: [
+          {
+            name: "double_tap_action",
             selector: {
               ui_action: {
-                default_action: "none" as const,
+                default_action: "none",
               },
             },
-          })
-        ),
+          },
+        ],
       },
     ],
   },

--- a/src/panels/lovelace/editor/config-elements/elements/hui-state-badge-element-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/elements/hui-state-badge-element-editor.ts
@@ -38,19 +38,27 @@ const SCHEMA = [
         },
       },
       {
+        name: "hold_action",
+        selector: {
+          ui_action: {
+            default_action: "more-info",
+          },
+        },
+      },
+      {
         name: "",
         type: "optional_actions",
         flatten: true,
-        schema: (["hold_action", "double_tap_action"] as const).map(
-          (action) => ({
-            name: action,
+        schema: [
+          {
+            name: "double_tap_action",
             selector: {
               ui_action: {
-                default_action: "none" as const,
+                default_action: "none",
               },
             },
-          })
-        ),
+          },
+        ],
       },
     ],
   },

--- a/src/panels/lovelace/editor/config-elements/elements/hui-state-icon-element-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/elements/hui-state-icon-element-editor.ts
@@ -50,19 +50,27 @@ const SCHEMA = [
         },
       },
       {
+        name: "hold_action",
+        selector: {
+          ui_action: {
+            default_action: "more-info",
+          },
+        },
+      },
+      {
         name: "",
         type: "optional_actions",
         flatten: true,
-        schema: (["hold_action", "double_tap_action"] as const).map(
-          (action) => ({
-            name: action,
+        schema: [
+          {
+            name: "double_tap_action",
             selector: {
               ui_action: {
-                default_action: "none" as const,
+                default_action: "none",
               },
             },
-          })
-        ),
+          },
+        ],
       },
     ],
   },

--- a/src/panels/lovelace/editor/config-elements/elements/hui-state-label-element-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/elements/hui-state-label-element-editor.ts
@@ -50,19 +50,27 @@ const SCHEMA = [
         },
       },
       {
+        name: "hold_action",
+        selector: {
+          ui_action: {
+            default_action: "more-info",
+          },
+        },
+      },
+      {
         name: "",
         type: "optional_actions",
         flatten: true,
-        schema: (["hold_action", "double_tap_action"] as const).map(
-          (action) => ({
-            name: action,
+        schema: [
+          {
+            name: "double_tap_action",
             selector: {
               ui_action: {
-                default_action: "none" as const,
+                default_action: "none",
               },
             },
-          })
-        ),
+          },
+        ],
       },
     ],
   },

--- a/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
@@ -72,19 +72,27 @@ const SCHEMA = [
         },
       },
       {
+        name: "hold_action",
+        selector: {
+          ui_action: {
+            default_action: "more-info",
+          },
+        },
+      },
+      {
         name: "",
         type: "optional_actions",
         flatten: true,
-        schema: (["hold_action", "double_tap_action"] as const).map(
-          (action) => ({
-            name: action,
+        schema: [
+          {
+            name: "double_tap_action",
             selector: {
               ui_action: {
-                default_action: "none" as const,
+                default_action: "none",
               },
             },
-          })
-        ),
+          },
+        ],
       },
     ],
   },

--- a/src/panels/lovelace/elements/hui-icon-element.ts
+++ b/src/panels/lovelace/elements/hui-icon-element.ts
@@ -31,7 +31,11 @@ export class HuiIconElement extends LitElement implements LovelaceElement {
       throw Error("Icon required");
     }
 
-    this._config = { tap_action: { action: "more-info" }, ...config };
+    this._config = {
+      tap_action: { action: "more-info" },
+      hold_action: { action: "more-info" },
+      ...config,
+    };
   }
 
   protected render() {

--- a/src/panels/lovelace/elements/hui-image-element.ts
+++ b/src/panels/lovelace/elements/hui-image-element.ts
@@ -29,7 +29,11 @@ export class HuiImageElement extends LitElement implements LovelaceElement {
       throw Error("Invalid configuration");
     }
 
-    this._config = { tap_action: { action: "more-info" }, ...config };
+    this._config = {
+      tap_action: { action: "more-info" },
+      hold_action: { action: "more-info" },
+      ...config,
+    };
 
     this.classList.toggle(
       "clickable",

--- a/src/panels/lovelace/elements/hui-state-badge-element.ts
+++ b/src/panels/lovelace/elements/hui-state-badge-element.ts
@@ -60,7 +60,11 @@ export class HuiStateBadgeElement
       throw Error("Entity required");
     }
 
-    this._config = { tap_action: { action: "more-info" }, ...config };
+    this._config = {
+      tap_action: { action: "more-info" },
+      hold_action: { action: "more-info" },
+      ...config,
+    };
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {

--- a/src/panels/lovelace/elements/hui-state-icon-element.ts
+++ b/src/panels/lovelace/elements/hui-state-icon-element.ts
@@ -60,6 +60,7 @@ export class HuiStateIconElement extends LitElement implements LovelaceElement {
     this._config = {
       state_color: true,
       tap_action: { action: "more-info" },
+      hold_action: { action: "more-info" },
       ...config,
     };
   }

--- a/src/panels/lovelace/elements/hui-state-label-element.ts
+++ b/src/panels/lovelace/elements/hui-state-label-element.ts
@@ -56,7 +56,11 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
       throw Error("Entity required");
     }
 
-    this._config = { tap_action: { action: "more-info" }, ...config };
+    this._config = {
+      tap_action: { action: "more-info" },
+      hold_action: { action: "more-info" },
+      ...config,
+    };
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {


### PR DESCRIPTION
## Proposed change

https://github.com/home-assistant/frontend/pull/24824 removed default more info hold actions. This PR restore the previous behavior. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/24912
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
