### PR TITLE
Update entity naming in entities config page

### DIFF
--- a/src/common/entity/compute_device_name.ts
+++ b/src/common/entity/compute_device_name.ts
@@ -1,3 +1,4 @@
+import memoizeOne from "memoize-one";
 import type { DeviceRegistryEntry } from "../../data/device_registry";
 import type {
   EntityRegistryDisplayEntry,
@@ -36,3 +37,23 @@ export const fallbackDeviceName = (
   }
   return undefined;
 };
+
+export const getDuplicatedDeviceNames = memoizeOne(
+  (devices: HomeAssistant["devices"]): Set<string> => {
+    const names = new Set<string>();
+    const duplicatedNames = new Set<string>();
+
+    for (const device of Object.values(devices)) {
+      const name = computeDeviceName(device);
+      if (!name) continue;
+
+      if (names.has(name)) {
+        duplicatedNames.add(name);
+      } else {
+        names.add(name);
+      }
+    }
+
+    return duplicatedNames;
+  }
+);

--- a/src/common/entity/compute_device_name.ts
+++ b/src/common/entity/compute_device_name.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../data/entity_registry";
 import type { HomeAssistant } from "../../types";
 import { computeStateName } from "./compute_state_name";
+import { getDuplicates } from "../string/get_duplicates";
 
 export const computeDeviceName = (
   device: DeviceRegistryEntry
@@ -40,20 +41,10 @@ export const fallbackDeviceName = (
 
 export const getDuplicatedDeviceNames = memoizeOne(
   (devices: HomeAssistant["devices"]): Set<string> => {
-    const names = new Set<string>();
-    const duplicatedNames = new Set<string>();
+    const names = Object.values(devices)
+      .map((device) => computeDeviceName(device))
+      .filter((name): name is string => name !== undefined);
 
-    for (const device of Object.values(devices)) {
-      const name = computeDeviceName(device);
-      if (!name) continue;
-
-      if (names.has(name)) {
-        duplicatedNames.add(name);
-      } else {
-        names.add(name);
-      }
-    }
-
-    return duplicatedNames;
+    return getDuplicates(names);
   }
 );

--- a/src/common/string/get_duplicates.ts
+++ b/src/common/string/get_duplicates.ts
@@ -1,0 +1,14 @@
+export function getDuplicates(array: string[]): Set<string> {
+  const duplicates = new Set<string>();
+  const seen = new Set<string>();
+
+  for (const item of array) {
+    if (seen.has(item)) {
+      duplicates.add(item);
+    } else {
+      seen.add(item);
+    }
+  }
+
+  return duplicates;
+}

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -497,7 +497,7 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
             : "",
       },
       name: {
-        title: localize("ui.panel.config.devices.data_table.name"),
+        title: localize("ui.panel.config.devices.data_table.device"),
         main: true,
         sortable: true,
         filterable: true,

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -667,7 +667,6 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         );
 
         const deviceName = device ? computeDeviceName(device) : undefined;
-        const areaName = area ? area.name : undefined;
 
         result.push({
           ...entry,

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -335,7 +335,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         title: localize("ui.panel.config.entities.picker.headers.entity_id"),
         sortable: true,
         filterable: true,
-        hidden: true,
+        defaultHidden: true,
       },
       localized_platform: {
         title: localize("ui.panel.config.entities.picker.headers.integration"),

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -826,7 +826,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         }
         selectable
         .selected=${this._selected.length}
-        .initialGroupColumn=${this._activeGrouping ?? "device"}
+        .initialGroupColumn=${this._activeGrouping ?? "device_full"}
         .initialCollapsedGroups=${this._activeCollapsed}
         .initialSorting=${this._activeSorting}
         .columnOrder=${this._activeColumnOrder}

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -25,15 +25,14 @@ import { computeCssColor } from "../../../common/color/compute-color";
 import { formatShortDateTimeWithConditionalYear } from "../../../common/datetime/format_date_time";
 import { storage } from "../../../common/decorators/storage";
 import type { HASSDomEvent } from "../../../common/dom/fire_event";
+import { computeDeviceName } from "../../../common/entity/compute_device_name";
 import { computeDomain } from "../../../common/entity/compute_domain";
-import {
-  isDeletableEntity,
-  deleteEntity,
-} from "../../../common/entity/delete_entity";
-import type { Helper } from "../helpers/const";
-import { isHelperDomain } from "../helpers/const";
-import { HELPERS_CRUD } from "../../../data/helpers_crud";
+import { computeEntityEntryName } from "../../../common/entity/compute_entity_name";
 import { computeStateName } from "../../../common/entity/compute_state_name";
+import {
+  deleteEntity,
+  isDeletableEntity,
+} from "../../../common/entity/delete_entity";
 import {
   PROTOCOL_INTEGRATIONS,
   protocolIntegrationPicked,
@@ -53,7 +52,6 @@ import "../../../components/data-table/ha-data-table-labels";
 import "../../../components/ha-alert";
 import "../../../components/ha-button-menu";
 import "../../../components/ha-check-list-item";
-import "../../../components/ha-md-divider";
 import "../../../components/ha-filter-devices";
 import "../../../components/ha-filter-domains";
 import "../../../components/ha-filter-floor-areas";
@@ -62,6 +60,7 @@ import "../../../components/ha-filter-labels";
 import "../../../components/ha-filter-states";
 import "../../../components/ha-icon";
 import "../../../components/ha-icon-button";
+import "../../../components/ha-md-divider";
 import "../../../components/ha-md-menu-item";
 import "../../../components/ha-sub-menu";
 import "../../../components/ha-svg-icon";
@@ -78,17 +77,15 @@ import type {
   EntityRegistryEntry,
   UpdateEntityRegistryEntryResult,
 } from "../../../data/entity_registry";
-import {
-  computeEntityRegistryName,
-  updateEntityRegistryEntry,
-} from "../../../data/entity_registry";
-import type { IntegrationManifest } from "../../../data/integration";
-import {
-  fetchIntegrationManifests,
-  domainToName,
-} from "../../../data/integration";
+import { updateEntityRegistryEntry } from "../../../data/entity_registry";
 import type { EntitySources } from "../../../data/entity_sources";
 import { fetchEntitySourcesWithCache } from "../../../data/entity_sources";
+import { HELPERS_CRUD } from "../../../data/helpers_crud";
+import type { IntegrationManifest } from "../../../data/integration";
+import {
+  domainToName,
+  fetchIntegrationManifests,
+} from "../../../data/integration";
 import type { LabelRegistryEntry } from "../../../data/label_registry";
 import {
   createLabelRegistryEntry,
@@ -106,6 +103,8 @@ import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../types";
 import { configSections } from "../ha-panel-config";
+import type { Helper } from "../helpers/const";
+import { isHelperDomain } from "../helpers/const";
 import "../integrations/ha-integration-overflow-menu";
 import { showAddIntegrationDialog } from "../integrations/show-add-integration-dialog";
 import { showLabelDetailDialog } from "../labels/show-dialog-label-detail";
@@ -124,6 +123,7 @@ export interface EntityRow extends StateEntity {
   restored: boolean;
   status: string | undefined;
   area?: string;
+  device?: string;
   localized_platform: string;
   domain: string;
   label_entries: LabelRegistryEntry[];
@@ -307,8 +307,6 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         title: localize("ui.panel.config.entities.picker.headers.name"),
         sortable: true,
         filterable: true,
-        direction: "asc",
-        flex: 2,
         extraTemplate: (entry) =>
           entry.label_entries.length
             ? html`
@@ -318,10 +316,26 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
               `
             : nothing,
       },
+      device: {
+        title: localize("ui.panel.config.entities.picker.headers.device"),
+        sortable: true,
+        filterable: true,
+        groupable: true,
+        direction: "asc",
+        template: (entry) => entry.device ?? "—",
+      },
+      area: {
+        title: localize("ui.panel.config.entities.picker.headers.area"),
+        sortable: true,
+        filterable: true,
+        groupable: true,
+        template: (entry) => entry.area ?? "—",
+      },
       entity_id: {
         title: localize("ui.panel.config.entities.picker.headers.entity_id"),
         sortable: true,
         filterable: true,
+        hidden: true,
       },
       localized_platform: {
         title: localize("ui.panel.config.entities.picker.headers.integration"),
@@ -333,12 +347,6 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         title: localize("ui.panel.config.entities.picker.headers.domain"),
         sortable: false,
         hidden: true,
-        filterable: true,
-        groupable: true,
-      },
-      area: {
-        title: localize("ui.panel.config.entities.picker.headers.area"),
-        sortable: true,
         filterable: true,
         groupable: true,
       },
@@ -624,8 +632,10 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         const entity = this.hass.states[entry.entity_id];
         const unavailable = entity?.state === UNAVAILABLE;
         const restored = entity?.attributes.restored === true;
-        const areaId = entry.area_id ?? devices[entry.device_id!]?.area_id;
+        const deviceId = entry.device_id;
+        const areaId = entry.area_id ?? devices[deviceId!]?.area_id;
         const area = areaId ? areas[areaId] : undefined;
+        const device = deviceId ? devices[deviceId] : undefined;
         const hidden = !!entry.hidden_by;
         const disabled = !!entry.disabled_by;
         const readonly = entry.readonly;
@@ -651,17 +661,23 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
           (lbl) => labelReg!.find((label) => label.label_id === lbl)!
         );
 
+        const entityName = computeEntityEntryName(
+          entry as EntityRegistryEntry,
+          this.hass
+        );
+
+        const deviceName = device ? computeDeviceName(device) : undefined;
+        const areaName = area ? area.name : undefined;
+
         result.push({
           ...entry,
           entity,
-          name: computeEntityRegistryName(
-            this.hass!,
-            entry as EntityRegistryEntry
-          ),
+          name: entityName || deviceName || entry.entity_id,
+          device: deviceName,
+          area: areaName,
           unavailable,
           restored,
           localized_platform: domainToName(localize, entry.platform),
-          area: area ? area.name : "—",
           domain: domainToName(localize, computeDomain(entry.entity_id)),
           status: restored
             ? localize("ui.panel.config.entities.picker.status.not_provided")

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -329,7 +329,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         sortable: true,
         filterable: true,
         groupable: true,
-        template: (entry) => entry.area ?? "—",
+        template: (entry) => entry.area || "—",
       },
       entity_id: {
         title: localize("ui.panel.config.entities.picker.headers.entity_id"),

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -674,7 +674,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
           entity,
           name: entityName || deviceName || entry.entity_id,
           device: deviceName,
-          area: areaName,
+          area: area?.name,
           unavailable,
           restored,
           localized_platform: domainToName(localize, entry.platform),

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -809,7 +809,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         }
         selectable
         .selected=${this._selected.length}
-        .initialGroupColumn=${this._activeGrouping}
+        .initialGroupColumn=${this._activeGrouping ?? "device"}
         .initialCollapsedGroups=${this._activeCollapsed}
         .initialSorting=${this._activeSorting}
         .columnOrder=${this._activeColumnOrder}

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -681,8 +681,8 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         const areaName = area ? computeAreaName(area) : undefined;
 
         const deviceFullName = deviceName
-          ? duplicatedDevicesNames.has(deviceName)
-            ? `${deviceName}${areaName ? ` (${areaName})` : ""}`
+          ? duplicatedDevicesNames.has(deviceName) && areaName
+            ? `${deviceName} (${areaName})`
             : deviceName
           : undefined;
 

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -108,6 +108,7 @@ import { isHelperDomain } from "../helpers/const";
 import "../integrations/ha-integration-overflow-menu";
 import { showAddIntegrationDialog } from "../integrations/show-add-integration-dialog";
 import { showLabelDetailDialog } from "../labels/show-dialog-label-detail";
+import { computeAreaName } from "../../../common/entity/compute_area_name";
 
 export interface StateEntity
   extends Omit<EntityRegistryEntry, "id" | "unique_id"> {
@@ -667,13 +668,14 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         );
 
         const deviceName = device ? computeDeviceName(device) : undefined;
+        const areaName = area ? computeAreaName(area) : undefined;
 
         result.push({
           ...entry,
           entity,
           name: entityName || deviceName || entry.entity_id,
           device: deviceName,
-          area: area?.name,
+          area: areaName,
           unavailable,
           restored,
           localized_platform: domainToName(localize, entry.platform),

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -304,9 +304,10 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
       },
       name: {
         main: true,
-        title: localize("ui.panel.config.entities.picker.headers.name"),
+        title: localize("ui.panel.config.entities.picker.headers.entity"),
         sortable: true,
         filterable: true,
+        direction: "asc",
         extraTemplate: (entry) =>
           entry.label_entries.length
             ? html`
@@ -321,7 +322,6 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         sortable: true,
         filterable: true,
         groupable: true,
-        direction: "asc",
         template: (entry) => entry.device || "—",
       },
       area: {

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -322,7 +322,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         filterable: true,
         groupable: true,
         direction: "asc",
-        template: (entry) => entry.device ?? "—",
+        template: (entry) => entry.device || "—",
       },
       area: {
         title: localize("ui.panel.config.entities.picker.headers.area"),

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -633,7 +633,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         const unavailable = entity?.state === UNAVAILABLE;
         const restored = entity?.attributes.restored === true;
         const deviceId = entry.device_id;
-        const areaId = entry.area_id ?? devices[deviceId!]?.area_id;
+        const areaId = entry.area_id || devices[deviceId!]?.area_id;
         const area = areaId ? areas[areaId] : undefined;
         const device = deviceId ? devices[deviceId] : undefined;
         const hidden = !!entry.hidden_by;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5005,6 +5005,7 @@
               "state_icon": "State icon",
               "name": "Name",
               "entity_id": "Entity ID",
+              "device": "Device",
               "integration": "Integration",
               "area": "Area",
               "disabled_by": "Disabled by",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4956,7 +4956,7 @@
           "disabled": "Disabled",
           "data_table": {
             "icon": "Icon",
-            "name": "Name",
+            "device": "Device",
             "manufacturer": "Manufacturer",
             "model": "Model",
             "area": "Area",
@@ -5003,7 +5003,7 @@
             },
             "headers": {
               "state_icon": "State icon",
-              "name": "Name",
+              "entity": "Entity",
               "entity_id": "Entity ID",
               "device": "Device",
               "integration": "Integration",


### PR DESCRIPTION
## Proposed change

Split the entity name into 2 columns : entity name and device name
Use new default columns : 
- State icon
- Entity (sort by)
- Device (group by) 
- Area
- Integration
- Status

In case or duplicated device name when grouping, the area will be display next to it in this format : `device_name (area_name)`.

Figma reference : https://www.figma.com/design/MA6vq4fQjc9VQZ1v0LsbNE/PDX-1735-Naming-and-displaying-more-meta-data?node-id=366-24774&t=TZMz9mBs5y5UYfUS-1

**Before**

![CleanShot 2025-04-09 at 10 49 06](https://github.com/user-attachments/assets/fc0b3390-a8e1-4b1c-bed5-19738e8a10d5)

**After**

![CleanShot 2025-04-09 at 10 52 12](https://github.com/user-attachments/assets/7eb64f9d-024b-424e-969a-88ef3095163e)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
