### PR TITLE
Update datatable in devices config page

### DIFF
--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -497,7 +497,7 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
             : "",
       },
       name: {
-        title: localize("ui.panel.config.devices.data_table.device"),
+        title: localize("ui.panel.config.devices.data_table.name"),
         main: true,
         sortable: true,
         filterable: true,
@@ -515,19 +515,6 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
             : nothing}
         `,
       },
-      manufacturer: {
-        title: localize("ui.panel.config.devices.data_table.manufacturer"),
-        sortable: true,
-        filterable: true,
-        groupable: true,
-        minWidth: "120px",
-      },
-      model: {
-        title: localize("ui.panel.config.devices.data_table.model"),
-        sortable: true,
-        filterable: true,
-        minWidth: "120px",
-      },
       area: {
         title: localize("ui.panel.config.devices.data_table.area"),
         sortable: true,
@@ -540,6 +527,19 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
         sortable: true,
         filterable: true,
         groupable: true,
+        minWidth: "120px",
+      },
+      manufacturer: {
+        title: localize("ui.panel.config.devices.data_table.manufacturer"),
+        sortable: true,
+        filterable: true,
+        groupable: true,
+        minWidth: "120px",
+      },
+      model: {
+        title: localize("ui.panel.config.devices.data_table.model"),
+        sortable: true,
+        filterable: true,
         minWidth: "120px",
       },
       battery_entity: {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4956,7 +4956,7 @@
           "disabled": "Disabled",
           "data_table": {
             "icon": "Icon",
-            "device": "Device",
+            "name": "Name",
             "manufacturer": "Manufacturer",
             "model": "Model",
             "area": "Area",


### PR DESCRIPTION
## Proposed change

Use new default columns : 
- Icon
- Name 
- Area
- Integration
- Manufacturer
- Model

Figma reference : https://www.figma.com/design/MA6vq4fQjc9VQZ1v0LsbNE/PDX-1735-Naming-and-displaying-more-meta-data?node-id=99-699&t=tVO03KF6TM881bO3-1

@marcinbauer85 I didn't sort them by area as the device name will not be ordered and I found it weird. Some people may also want to sort it by manufacturer or model.

**Before**

![CleanShot 2025-04-08 at 10 35 34](https://github.com/user-attachments/assets/d9e95d29-2f50-46f6-9c8a-993a32d41be2)

**After**

![CleanShot 2025-04-08 at 10 35 41](https://github.com/user-attachments/assets/65d60056-20d0-4cb0-bc44-eaa5d9c56bd4)
## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
