### PR TITLE
Migrate icon overflow menu to `ha-md-button-menu`

### DIFF
--- a/src/components/ha-icon-overflow-menu.ts
+++ b/src/components/ha-icon-overflow-menu.ts
@@ -5,11 +5,13 @@ import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
-import "./ha-button-menu";
+import "./ha-md-button-menu";
 import "./ha-icon-button";
 import "./ha-list-item";
 import "./ha-svg-icon";
 import "./ha-tooltip";
+import "./ha-md-menu-item";
+import "./ha-md-divider";
 
 export interface IconOverflowMenuItem {
   [key: string]: any;
@@ -35,11 +37,9 @@ export class HaIconOverflowMenu extends LitElement {
     return html`
       ${this.narrow
         ? html` <!-- Collapsed representation for small screens -->
-            <ha-button-menu
+            <ha-md-button-menu
               @click=${this._handleIconOverflowMenuOpened}
-              @closed=${this._handleIconOverflowMenuClosed}
-              class="ha-icon-overflow-menu-overflow"
-              absolute
+              positioning="popover"
             >
               <ha-icon-button
                 .label=${this.hass.localize("ui.common.overflow_menu")}
@@ -49,23 +49,24 @@ export class HaIconOverflowMenu extends LitElement {
 
               ${this.items.map((item) =>
                 item.divider
-                  ? html`<li divider role="separator"></li>`
-                  : html`<ha-list-item
-                      graphic="icon"
+                  ? html`<ha-md-divider
+                      role="separator"
+                      tabindex="-1"
+                    ></ha-md-divider>`
+                  : html`<ha-md-menu-item
                       ?disabled=${item.disabled}
-                      @click=${item.action}
+                      .clickAction=${item.action}
                       class=${classMap({ warning: Boolean(item.warning) })}
                     >
-                      <div slot="graphic">
-                        <ha-svg-icon
-                          class=${classMap({ warning: Boolean(item.warning) })}
-                          .path=${item.path}
-                        ></ha-svg-icon>
-                      </div>
+                      <ha-svg-icon
+                        slot="start"
+                        class=${classMap({ warning: Boolean(item.warning) })}
+                        .path=${item.path}
+                      ></ha-svg-icon>
                       ${item.label}
-                    </ha-list-item> `
+                    </ha-md-menu-item> `
               )}
-            </ha-button-menu>`
+            </ha-md-button-menu>`
         : html`
             <!-- Icon representation for big screens -->
             ${this.items.map((item) =>
@@ -91,20 +92,6 @@ export class HaIconOverflowMenu extends LitElement {
 
   protected _handleIconOverflowMenuOpened(e) {
     e.stopPropagation();
-    // If this component is used inside a data table, the z-index of the row
-    // needs to be increased. Otherwise the ha-button-menu would be displayed
-    // underneath the next row in the table.
-    const row = this.closest(".mdc-data-table__row") as HTMLDivElement | null;
-    if (row) {
-      row.style.zIndex = "1";
-    }
-  }
-
-  protected _handleIconOverflowMenuClosed() {
-    const row = this.closest(".mdc-data-table__row") as HTMLDivElement | null;
-    if (row) {
-      row.style.zIndex = "";
-    }
   }
 
   static get styles() {
@@ -115,15 +102,9 @@ export class HaIconOverflowMenu extends LitElement {
           display: flex;
           justify-content: flex-end;
         }
-        li[role="separator"] {
-          border-bottom-color: var(--divider-color);
-        }
         div[role="separator"] {
           border-right: 1px solid var(--divider-color);
           width: 1px;
-        }
-        ha-list-item[disabled] ha-svg-icon {
-          color: var(--disabled-text-color);
         }
       `,
     ];


### PR DESCRIPTION
## Proposed change
Migrate `ha-icon-overflow-menu` to use `ha-md-button-menu` to fix the overflow menu hidden by the FAB.
The icons are a bit smaller now but aligned with the other icon sizes in HA.

| Before | After |
|:-:|:-:|
| <img width="745" alt="image" src="https://github.com/user-attachments/assets/476911d2-068f-4c9e-8a77-41ae006ef51b" /> | <img width="747" alt="image" src="https://github.com/user-attachments/assets/a038e467-9373-4326-ba68-8f96416de568" /> |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21043
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
