### PR TITLE
Restore no grouping from local storage from datatable

### DIFF
--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -343,7 +343,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
             <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
             <ha-md-menu-item
               .clickAction=${this._collapseAllGroups}
-              .disabled=${this._groupColumn === undefined}
+              .disabled=${!this._groupColumn}
             >
               <ha-svg-icon
                 slot="start"
@@ -355,7 +355,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
             </ha-md-menu-item>
             <ha-md-menu-item
               .clickAction=${this._expandAllGroups}
-              .disabled=${this._groupColumn === undefined}
+              .disabled=${!this._groupColumn}
             >
               <ha-svg-icon
                 slot="start"

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -333,10 +333,10 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
                 : nothing
             )}
             <ha-md-menu-item
-              .value=${undefined}
+              .value=${""}
               .clickAction=${this._handleGroupBy}
-              .selected=${this._groupColumn === undefined}
-              class=${classMap({ selected: this._groupColumn === undefined })}
+              .selected=${!this._groupColumn}
+              class=${classMap({ selected: !this._groupColumn })}
             >
               ${localize("ui.components.subpage-data-table.dont_group_by")}
             </ha-md-menu-item>


### PR DESCRIPTION
## Proposed change

Previously, if the user clicked "don't group", it would set the initial grouping (e.g. grouped category from automations).
With this change, it will save empty string in the local storage to save the "no grouping" choice.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
