### PR TITLE
Hide hardware integrations without entities

### DIFF
--- a/src/panels/config/integrations/ha-config-integrations-dashboard.ts
+++ b/src/panels/config/integrations/ha-config-integrations-dashboard.ts
@@ -170,6 +170,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
       components: string[],
       manifests: Record<string, IntegrationManifest>,
       configEntries: ConfigEntryExtended[],
+      entityEntries: EntityRegistryEntry[],
       localize: HomeAssistant["localize"],
       filter?: string
     ): [
@@ -218,7 +219,16 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
         })
       );
 
-      const allEntries = [...configEntries, ...nonConfigEntry];
+      const allEntries = [
+        ...configEntries.filter(
+          (entry) =>
+            this._manifests[entry.domain]?.integration_type !== "hardware" ||
+            entityEntries.find(
+              (entity) => entity.config_entry_id === entry.entry_id
+            )
+        ),
+        ...nonConfigEntry,
+      ];
 
       let filteredConfigEntries: ConfigEntryExtended[];
       const ignored: ConfigEntryExtended[] = [];
@@ -380,6 +390,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
         this.hass.config.components,
         this._manifests,
         this.configEntries,
+        this._entityRegistryEntries,
         this.hass.localize,
         this._filter
       );


### PR DESCRIPTION



## Proposed change

Last release hardware integrations where unhidden from the integration page in core, this hides most of them again, except for the ones that have entities.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
