### PR TITLE
Fix data-table group by unknown column

### DIFF
--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -204,10 +204,10 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
     if (this.hasUpdated) {
       return;
     }
-    if (this.initialGroupColumn) {
+    if (this.initialGroupColumn && this.columns[this.initialGroupColumn]) {
       this._setGroupColumn(this.initialGroupColumn);
     }
-    if (this.initialSorting) {
+    if (this.initialSorting && this.columns[this.initialSorting.column]) {
       this._sortColumn = this.initialSorting.column;
       this._sortDirection = this.initialSorting.direction;
     }
@@ -307,9 +307,10 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
           <ha-md-button-menu positioning="popover">
             <ha-assist-chip
               .label=${localize("ui.components.subpage-data-table.group_by", {
-                groupColumn: this._groupColumn
-                  ? ` ${this.columns[this._groupColumn].title || this.columns[this._groupColumn].label}`
-                  : "",
+                groupColumn:
+                  this._groupColumn && this.columns[this._groupColumn]
+                    ? ` ${this.columns[this._groupColumn].title || this.columns[this._groupColumn].label}`
+                    : "",
               })}
               slot="trigger"
             >


### PR DESCRIPTION
## Proposed change

The grouping column can be set to an non-existing column when restoring from the local-storage which causes a data-table crash.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
