### PR TITLE
Render low carbon gauge when only solar consumption

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-carbon-consumed-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-carbon-consumed-gauge-card.ts
@@ -95,14 +95,15 @@ class HuiEnergyCarbonGaugeCard
     const prefs = this._data.prefs;
     const types = energySourcesByType(prefs);
 
-    const totalGridConsumption = calculateStatisticsSumGrowth(
-      this._data.stats,
-      types.grid![0].flow_from.map((flow) => flow.stat_energy_from)
-    );
+    const totalGridConsumption =
+      calculateStatisticsSumGrowth(
+        this._data.stats,
+        types.grid![0].flow_from.map((flow) => flow.stat_energy_from)
+      ) ?? 0;
 
     let value: number | undefined;
 
-    if (this._data.fossilEnergyConsumption && totalGridConsumption != null) {
+    if (this._data.fossilEnergyConsumption) {
       const highCarbonEnergy = this._data.fossilEnergyConsumption
         ? Object.values(this._data.fossilEnergyConsumption).reduce(
             (sum, a) => sum + a,

--- a/src/panels/lovelace/cards/energy/hui-energy-carbon-consumed-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-carbon-consumed-gauge-card.ts
@@ -102,7 +102,7 @@ class HuiEnergyCarbonGaugeCard
 
     let value: number | undefined;
 
-    if (this._data.fossilEnergyConsumption && totalGridConsumption) {
+    if (this._data.fossilEnergyConsumption && totalGridConsumption != null) {
       const highCarbonEnergy = this._data.fossilEnergyConsumption
         ? Object.values(this._data.fossilEnergyConsumption).reduce(
             (sum, a) => sum + a,
@@ -127,7 +127,9 @@ class HuiEnergyCarbonGaugeCard
         totalGridConsumption +
         Math.max(0, totalSolarProduction - totalGridReturned);
 
-      value = round((1 - highCarbonEnergy / totalEnergyConsumed) * 100);
+      if (totalEnergyConsumed) {
+        value = round((1 - highCarbonEnergy / totalEnergyConsumed) * 100);
+      }
     }
 
     return html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

If solar consumption is included in the low-carbon denominator, it makes sense that having only solar consumption and 0 grid consumption should make the gauge to render at 100%, not undefined. (I agree not to render if there is no consumption of _any_ kind)


This seems directly contrary to https://github.com/home-assistant/frontend/pull/14020 by @piitaya , so maybe you can check if you agree with this reasoning?



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24958
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
