### PR TITLE
Only ask to refresh dashboard if necessary

### DIFF
--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -239,7 +239,7 @@ export class HUIView extends ReactiveElement {
     // Don't ask if the config is the same
     if (!deepEqual(newConfig, oldConfig)) {
       if (force) {
-        this._initializeConfig();
+        this._setConfig(newConfig, true);
       } else {
         fireEvent(this, "strategy-config-changed");
       }
@@ -321,12 +321,10 @@ export class HUIView extends ReactiveElement {
     };
   }
 
-  private async _initializeConfig() {
-    const rawConfig = this.lovelace.config.views[this.index];
-    const isStrategy = isStrategyView(rawConfig);
-
-    const viewConfig = await this._generateConfig(rawConfig);
-
+  private async _setConfig(
+    viewConfig: LovelaceViewConfig,
+    isStrategy: boolean
+  ) {
     // Create a new layout element if necessary.
     let addLayoutElement = false;
 
@@ -353,6 +351,15 @@ export class HUIView extends ReactiveElement {
       }
       this.appendChild(this._layoutElement!);
     }
+  }
+
+  private async _initializeConfig() {
+    const rawConfig = this.lovelace.config.views[this.index];
+
+    const viewConfig = await this._generateConfig(rawConfig);
+    const isStrategy = isStrategyView(viewConfig);
+
+    this._setConfig(viewConfig, isStrategy);
   }
 
   private _createLayoutElement(config: LovelaceViewConfig): void {


### PR DESCRIPTION
## Proposed change

Regenerate dashboard and view strategies when registries changed. 

If the dashboard config changed : 
- ask the user to refresh the dashboard

If the view config changed : 
- if the view is displayed : ask the user to refresh the dashboard
- if the view is not displayed (in cache) : refresh the view when the user enter the page, we don't need to ask, we can just refresh it. 

I'm not very fan of the implementation as it introduces complexity but I didn't found any other way to do it.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
