### PR TITLE
Add prevent restart when backup is ongoing

### DIFF
--- a/src/data/backup_manager.ts
+++ b/src/data/backup_manager.ts
@@ -58,6 +58,12 @@ interface RestoreBackupEvent {
   state: RestoreBackupState;
 }
 
+export type ManagerState =
+  | "idle"
+  | "create_backup"
+  | "receive_backup"
+  | "restore_backup";
+
 export type ManagerStateEvent =
   | IdleEvent
   | CreateBackupEvent

--- a/src/dialogs/restart/dialog-restart-wait.ts
+++ b/src/dialogs/restart/dialog-restart-wait.ts
@@ -4,6 +4,7 @@ import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import "../../components/ha-alert";
 import "../../components/ha-dialog-header";
 import "../../components/ha-icon-button";
 import "../../components/ha-md-dialog";
@@ -28,6 +29,9 @@ class DialogRestartWait extends LitElement {
   private _title = "";
 
   private _actionOnIdle?: () => Promise<void>;
+
+  @state()
+  private _error?: string;
 
   @state()
   private _backupState?: ManagerState;
@@ -97,8 +101,16 @@ class DialogRestartWait extends LitElement {
           <span slot="title" .title=${this._title}> ${this._title} </span>
         </ha-dialog-header>
         <div slot="content" class="content">
-          <ha-spinner></ha-spinner>
-          ${waitMessage}
+          ${this._error
+            ? html`<ha-alert alert-type="error"
+                >${this.hass.localize("ui.dialogs.restart.error_backup_state", {
+                  error: this._error,
+                })}</ha-alert
+              > `
+            : html`
+                <ha-spinner></ha-spinner>
+                ${waitMessage}
+              `}
         </div>
       </ha-md-dialog>
     `;
@@ -125,10 +137,8 @@ class DialogRestartWait extends LitElement {
           }
         }
       );
-    } catch (err) {
-      // TODO show error to user
-      // eslint-disable-next-line no-console
-      console.error(err);
+    } catch (err: any) {
+      this._error = err.message || err;
     }
   }
 

--- a/src/dialogs/restart/dialog-restart-wait.ts
+++ b/src/dialogs/restart/dialog-restart-wait.ts
@@ -1,0 +1,165 @@
+import { mdiClose } from "@mdi/js";
+import type { UnsubscribeFunc } from "home-assistant-js-websocket";
+import type { CSSResultGroup } from "lit";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { fireEvent } from "../../common/dom/fire_event";
+import "../../components/ha-dialog-header";
+import "../../components/ha-icon-button";
+import "../../components/ha-md-dialog";
+import type { HaMdDialog } from "../../components/ha-md-dialog";
+import "../../components/ha-spinner";
+import { fetchBackupInfo } from "../../data/backup";
+import {
+  subscribeBackupEvents,
+  type ManagerState,
+} from "../../data/backup_manager";
+import { haStyle, haStyleDialog } from "../../resources/styles";
+import type { HomeAssistant } from "../../types";
+import type { RestartWaitDialogParams } from "./show-dialog-restart";
+
+@customElement("dialog-restart-wait")
+class DialogRestartWait extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _open = false;
+
+  @state()
+  private _title = "";
+
+  private _actionOnIdle?: () => Promise<void>;
+
+  @state()
+  private _backupState?: ManagerState;
+
+  private _backupEventsSubscription?: UnsubscribeFunc;
+
+  @query("ha-md-dialog") private _dialog?: HaMdDialog;
+
+  public async showDialog(params: RestartWaitDialogParams): Promise<void> {
+    this._open = true;
+    this._loadBackupState();
+
+    this._title = params.title;
+    this._backupState = params.initialBackupState;
+
+    this._actionOnIdle = params.action;
+  }
+
+  private _dialogClosed(): void {
+    this._open = false;
+
+    if (this._backupEventsSubscription) {
+      this._backupEventsSubscription();
+      this._backupEventsSubscription = undefined;
+    }
+
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  public closeDialog(): void {
+    this._dialog?.close();
+  }
+
+  private _getWaitMessage() {
+    switch (this._backupState) {
+      case "create_backup":
+        return this.hass.localize("ui.dialogs.restart.wait_for_backup");
+      case "receive_backup":
+        return this.hass.localize("ui.dialogs.restart.wait_for_upload");
+      case "restore_backup":
+        return this.hass.localize("ui.dialogs.restart.wait_for_restore");
+      default:
+        return "";
+    }
+  }
+
+  protected render() {
+    if (!this._open) {
+      return nothing;
+    }
+
+    const waitMessage = this._getWaitMessage();
+
+    return html`
+      <ha-md-dialog
+        open
+        @closed=${this._dialogClosed}
+        .disableCancelAction=${true}
+      >
+        <ha-dialog-header slot="headline">
+          <ha-icon-button
+            slot="navigationIcon"
+            .label=${this.hass.localize("ui.common.cancel")}
+            .path=${mdiClose}
+            @click=${this.closeDialog}
+          ></ha-icon-button>
+          <span slot="title" .title=${this._title}> ${this._title} </span>
+        </ha-dialog-header>
+        <div slot="content" class="content">
+          <ha-spinner></ha-spinner>
+          ${waitMessage}
+        </div>
+      </ha-md-dialog>
+    `;
+  }
+
+  private async _loadBackupState() {
+    try {
+      const { state: backupState } = await fetchBackupInfo(this.hass);
+      this._backupState = backupState;
+
+      if (this._backupState === "idle") {
+        this.closeDialog();
+        await this._actionOnIdle?.();
+        return;
+      }
+
+      this._backupEventsSubscription = await subscribeBackupEvents(
+        this.hass,
+        async (event) => {
+          this._backupState = event.manager_state;
+          if (this._backupState === "idle") {
+            this.closeDialog();
+            await this._actionOnIdle?.();
+          }
+        }
+      );
+    } catch (err) {
+      // TODO show error to user
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      haStyleDialog,
+      css`
+        ha-md-dialog {
+          --dialog-content-padding: 0;
+        }
+        @media all and (min-width: 550px) {
+          ha-md-dialog {
+            min-width: 500px;
+            max-width: 500px;
+          }
+        }
+        .content {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          padding: 24px;
+          gap: 32px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-restart-wait": DialogRestartWait;
+  }
+}

--- a/src/dialogs/restart/show-dialog-restart.ts
+++ b/src/dialogs/restart/show-dialog-restart.ts
@@ -1,13 +1,32 @@
 import { fireEvent } from "../../common/dom/fire_event";
+import type { ManagerState } from "../../data/backup_manager";
 
 export interface RestartDialogParams {}
 
 export const loadRestartDialog = () => import("./dialog-restart");
+export const loadRestartWaitDialog = () => import("./dialog-restart-wait");
 
 export const showRestartDialog = (element: HTMLElement): void => {
   fireEvent(element, "show-dialog", {
     dialogTag: "dialog-restart",
     dialogImport: loadRestartDialog,
     dialogParams: {},
+  });
+};
+
+export interface RestartWaitDialogParams {
+  title: string;
+  initialBackupState: ManagerState;
+  action: () => Promise<void>;
+}
+
+export const showRestartWaitDialog = (
+  element: HTMLElement,
+  dialogParams: RestartWaitDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-restart-wait",
+    dialogImport: loadRestartWaitDialog,
+    dialogParams,
   });
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1543,6 +1543,7 @@
         "upload_in_progress": "A backup upload is currently in progress. The action will automatically proceed once the upload process is complete.",
         "restore_in_progress": "A backup restore is currently in progress. The action will automatically proceed once the restore process is complete.",
         "wait_for_backup": "Wait for the backup creation to finish",
+        "error_backup_state": "An error occured while getting the current backup state. Error: {error}",
         "wait_for_upload": "Wait for backup upload to finish",
         "wait_for_restore": "Wait for backup restore to finish",
         "reload": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1560,6 +1560,11 @@
           "confirm_action_backup": "Wait and restart",
           "failed": "Failed to restart Home Assistant"
         },
+        "stop": {
+          "confirm_title": "Stop Home Assistant?",
+          "confirm_description": "This will interrupt all running automations and scripts.",
+          "confirm_action": "Stop"
+        },
         "reboot": {
           "title": "Reboot system",
           "description": "Restarts the system running Home Assistant and all add-ons.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1539,6 +1539,12 @@
       "restart": {
         "heading": "Restart Home Assistant",
         "advanced_options": "Advanced options",
+        "backup_in_progress": "A backup is currently being created. The action will automatically proceed once the backup process is complete.",
+        "upload_in_progress": "A backup upload is currently in progress. The action will automatically proceed once the upload process is complete.",
+        "restore_in_progress": "A backup restore is currently in progress. The action will automatically proceed once the restore process is complete.",
+        "wait_for_backup": "Wait for the backup creation to finish",
+        "wait_for_upload": "Wait for backup upload to finish",
+        "wait_for_restore": "Wait for backup restore to finish",
         "reload": {
           "title": "Quick reload",
           "description": "Loads new YAML configurations without a restart.",
@@ -1551,12 +1557,8 @@
           "confirm_title": "Restart Home Assistant?",
           "confirm_description": "This will interrupt all running automations and scripts.",
           "confirm_action": "Restart",
+          "confirm_action_backup": "Wait and restart",
           "failed": "Failed to restart Home Assistant"
-        },
-        "stop": {
-          "confirm_title": "Stop Home Assistant?",
-          "confirm_description": "This will interrupt all running automations and scripts.",
-          "confirm_action": "Stop"
         },
         "reboot": {
           "title": "Reboot system",
@@ -1564,7 +1566,8 @@
           "confirm_title": "Reboot system?",
           "confirm_description": "This will reboot the complete system which includes Home Assistant and all the add-ons.",
           "confirm_action": "Reboot",
-          "rebooting": "Rebooting system",
+          "action_toast": "Rebooting system",
+          "confirm_action_backup": "Wait and reboot",
           "failed": "Failed to reboot system"
         },
         "shutdown": {
@@ -1573,7 +1576,8 @@
           "confirm_title": "Shut down system?",
           "confirm_description": "This will shut down the complete system which includes Home Assistant and all add-ons.",
           "confirm_action": "Shut down",
-          "shutting_down": "Shutting down system",
+          "confirm_action_backup": "Wait and shut down",
+          "action_toast": "Shutting down system",
           "failed": "Failed to shut down system"
         },
         "restart-safe-mode": {
@@ -1582,6 +1586,7 @@
           "confirm_title": "Restart Home Assistant in safe mode?",
           "confirm_description": "This will restart Home Assistant without loading any custom integrations and frontend modules.",
           "confirm_action": "Restart",
+          "confirm_action_backup": "Wait and Restart",
           "failed": "Failed to restart Home Assistant"
         }
       },


### PR DESCRIPTION
## Proposed change
- Prevent restart, reboot and shutdown when backup creation, restore or upload is in progress

![image](https://github.com/user-attachments/assets/ebb62539-ecb2-439a-b5d4-83f92d561d71)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
