### PR TITLE
Add a tile-badge for active light effects

### DIFF
--- a/src/panels/lovelace/cards/tile/badges/tile-badge-light.ts
+++ b/src/panels/lovelace/cards/tile/badges/tile-badge-light.ts
@@ -1,0 +1,20 @@
+import { html, nothing } from "lit";
+import "../../../../../components/ha-attribute-icon";
+import "../../../../../components/tile/ha-tile-badge";
+import type { RenderBadgeFunction } from "./tile-badge";
+import type { LightEntity } from "../../../../../data/light";
+
+export const renderLightBadge: RenderBadgeFunction = (stateObj, hass) => {
+  const lightEffect = (stateObj as LightEntity).attributes.effect;
+
+  if (!lightEffect || ["off", "none"].includes(lightEffect.toLowerCase())) {
+    return nothing;
+  }
+
+  return html`
+    <ha-tile-badge>
+      <ha-attribute-icon .hass=${hass} .stateObj=${stateObj} attribute="effect">
+      </ha-attribute-icon>
+    </ha-tile-badge>
+  `;
+};

--- a/src/panels/lovelace/cards/tile/badges/tile-badge.ts
+++ b/src/panels/lovelace/cards/tile/badges/tile-badge.ts
@@ -9,6 +9,7 @@ import type { HomeAssistant } from "../../../../../types";
 import { renderClimateBadge } from "./tile-badge-climate";
 import { renderHumidifierBadge } from "./tile-badge-humidifier";
 import { renderPersonBadge } from "./tile-badge-person";
+import { renderLightBadge } from "./tile-badge-light";
 import "../../../../../components/tile/ha-tile-badge";
 import "../../../../../components/ha-svg-icon";
 
@@ -41,6 +42,8 @@ export const renderTileBadge: RenderBadgeFunction = (stateObj, hass) => {
       return renderClimateBadge(stateObj, hass);
     case "humidifier":
       return renderHumidifierBadge(stateObj, hass);
+    case "light":
+      return renderLightBadge(stateObj, hass);
     default:
       return nothing;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Had an idea to show a badge if a light has an active effect (w/ the effect icon):  
![image](https://github.com/user-attachments/assets/d87dd7fd-95db-4627-a274-dddc586f5f1f)

Could be a problem if some integrations don't have well established effect icons, in which case this would just show the "dot" icon here which is maybe not a great visual. Maybe we could just hardcoded check to see if the icon is the dot icon and either not show this badge in that case, or replace it with something like `mdi:shimmer` instead? 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
