### PR TITLE
Link the device info BLE address to the Advertisement Monitor

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-info-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-info-card.ts
@@ -104,12 +104,13 @@ export class HaDeviceCard extends LitElement {
             ([type, value]) => html`
               <div class="extra-info">
                 ${type === "bluetooth"
-                  ? html`<a
-                      href="/config/bluetooth/advertisement-monitor?${createSearchParam(
-                        { address: value }
-                      )}"
-                      >${titleCase(type)} ${value.toUpperCase()}</a
-                    >`
+                  ? html`${titleCase(type)}
+                      <a
+                        href="/config/bluetooth/advertisement-monitor?${createSearchParam(
+                          { address: value }
+                        )}"
+                        >${value.toUpperCase()}</a
+                      >`
                   : html`${type === "mac" ? "MAC" : titleCase(type)}:
                     ${value.toUpperCase()}`}
               </div>

--- a/src/panels/config/devices/device-detail/ha-device-info-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-info-card.ts
@@ -7,6 +7,7 @@ import "../../../../components/ha-card";
 import type { DeviceRegistryEntry } from "../../../../data/device_registry";
 import { haStyle } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
+import { createSearchParam } from "../../../../common/url/search-params";
 
 @customElement("ha-device-info-card")
 export class HaDeviceCard extends LitElement {
@@ -102,8 +103,15 @@ export class HaDeviceCard extends LitElement {
           ${this._getAddresses().map(
             ([type, value]) => html`
               <div class="extra-info">
-                ${type === "mac" ? "MAC" : titleCase(type)}:
-                ${value.toUpperCase()}
+                ${type === "bluetooth"
+                  ? html`<a
+                      href="/config/bluetooth/advertisement-monitor?${createSearchParam(
+                        { address: value }
+                      )}"
+                      >${titleCase(type)} ${value.toUpperCase()}</a
+                    >`
+                  : html`${type === "mac" ? "MAC" : titleCase(type)}:
+                    ${value.toUpperCase()}`}
               </div>
             `
           )}

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-advertisement-monitor.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-advertisement-monitor.ts
@@ -66,7 +66,6 @@ export class BluetoothAdvertisementMonitorPanel extends LitElement {
 
   public connectedCallback(): void {
     super.connectedCallback();
-    window.addEventListener("location-changed", this._locationChanged);
     if (this.hass) {
       this._unsub_advertisements = subscribeBluetoothAdvertisements(
         this.hass.connection,
@@ -98,7 +97,6 @@ export class BluetoothAdvertisementMonitorPanel extends LitElement {
 
   public disconnectedCallback() {
     super.disconnectedCallback();
-    window.removeEventListener("location-changed", this._locationChanged);
     if (this._unsub_advertisements) {
       this._unsub_advertisements();
       this._unsub_advertisements = undefined;
@@ -116,14 +114,6 @@ export class BluetoothAdvertisementMonitorPanel extends LitElement {
       return;
     }
 
-    this._applyURLParams();
-  }
-
-  private _locationChanged = () => {
-    this._applyURLParams();
-  };
-
-  private _applyURLParams() {
     const searchParams = extractSearchParamsObject();
     const address = searchParams.address;
     if (address) {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When troubleshooting https://github.com/home-assistant/core/issues/142768 it would have been nice to tell the user to click on the mac address to find the advertising data instead of them having to type in the url manually.

<img width="302" alt="Screenshot 2025-04-13 at 4 00 38 PM" src="https://github.com/user-attachments/assets/4f045108-06da-4c5a-b36a-b3346b183b5a" />
<img width="1032" alt="Screenshot 2025-04-13 at 4 00 35 PM" src="https://github.com/user-attachments/assets/4b7eb5e8-8fc0-4bad-a662-eb69f07d95dd" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
