### PR TITLE
Fix safe area inset in sidebar

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -901,6 +901,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
           --md-list-item-leading-icon-size: 24px;
         }
         :host([expanded]) ha-md-list-item {
+          width: 248px;
           width: calc(248px - env(safe-area-inset-left));
         }
 

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -253,8 +253,10 @@ class HaSidebar extends SubscribeMixin(LitElement) {
       ${this._renderHeader()}
       ${this._renderAllPanels(selectedPanel)}
       ${this._renderDivider()}
-      ${this._renderNotifications()}
-      ${this._renderUserItem(selectedPanel)}
+      <ha-md-list>
+        ${this._renderNotifications()}
+        ${this._renderUserItem(selectedPanel)}
+      </ha-md-list>
       <div disabled class="bottom-spacer"></div>
       <div class="tooltip"></div>
     `;
@@ -899,7 +901,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
           --md-list-item-leading-icon-size: 24px;
         }
         :host([expanded]) ha-md-list-item {
-          width: 248px;
+          width: calc(248px - env(safe-area-inset-left));
         }
 
         ha-md-list-item.selected {
@@ -923,6 +925,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
 
         ha-icon[slot="start"],
         ha-svg-icon[slot="start"] {
+          width: 24px;
           flex-shrink: 0;
           color: var(--sidebar-icon-color);
         }


### PR DESCRIPTION


## Proposed change
Menu items where too wide when there was a safe area inset left.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
