### PR TITLE
Extend usage of Data Entry Flow forms description_placeholders to field labels

### DIFF
--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -81,7 +81,8 @@ export const showConfigFlowDialog = (
     renderShowFormStepFieldLabel(hass, step, field, options) {
       if (field.type === "expandable") {
         return hass.localize(
-          `component.${step.handler}.config.step.${step.step_id}.sections.${field.name}.name`
+          `component.${step.handler}.config.step.${step.step_id}.sections.${field.name}.name`,
+          step.description_placeholders
         );
       }
 
@@ -89,7 +90,8 @@ export const showConfigFlowDialog = (
 
       return (
         hass.localize(
-          `component.${step.handler}.config.step.${step.step_id}.${prefix}data.${field.name}`
+          `component.${step.handler}.config.step.${step.step_id}.${prefix}data.${field.name}`,
+          step.description_placeholders
         ) || field.name
       );
     },
@@ -97,7 +99,8 @@ export const showConfigFlowDialog = (
     renderShowFormStepFieldHelper(hass, step, field, options) {
       if (field.type === "expandable") {
         return hass.localize(
-          `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.sections.${field.name}.description`
+          `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.sections.${field.name}.description`,
+          step.description_placeholders
         );
       }
 

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -96,7 +96,8 @@ export const showOptionsFlowDialog = (
       renderShowFormStepFieldLabel(hass, step, field, options) {
         if (field.type === "expandable") {
           return hass.localize(
-            `component.${configEntry.domain}.options.step.${step.step_id}.sections.${field.name}.name`
+            `component.${configEntry.domain}.options.step.${step.step_id}.sections.${field.name}.name`,
+            step.description_placeholders
           );
         }
 
@@ -104,7 +105,8 @@ export const showOptionsFlowDialog = (
 
         return (
           hass.localize(
-            `component.${configEntry.domain}.options.step.${step.step_id}.${prefix}data.${field.name}`
+            `component.${configEntry.domain}.options.step.${step.step_id}.${prefix}data.${field.name}`,
+            step.description_placeholders
           ) || field.name
         );
       },
@@ -112,7 +114,8 @@ export const showOptionsFlowDialog = (
       renderShowFormStepFieldHelper(hass, step, field, options) {
         if (field.type === "expandable") {
           return hass.localize(
-            `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.sections.${field.name}.description`
+            `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.sections.${field.name}.description`,
+            step.description_placeholders
           );
         }
 

--- a/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
@@ -87,7 +87,8 @@ export const showSubConfigFlowDialog = (
     renderShowFormStepFieldLabel(hass, step, field, options) {
       if (field.type === "expandable") {
         return hass.localize(
-          `component.${configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.sections.${field.name}.name`
+          `component.${configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.sections.${field.name}.name`,
+          step.description_placeholders
         );
       }
 
@@ -95,7 +96,8 @@ export const showSubConfigFlowDialog = (
 
       return (
         hass.localize(
-          `component.${configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.${prefix}data.${field.name}`
+          `component.${configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.${prefix}data.${field.name}`,
+          step.description_placeholders
         ) || field.name
       );
     },
@@ -103,7 +105,8 @@ export const showSubConfigFlowDialog = (
     renderShowFormStepFieldHelper(hass, step, field, options) {
       if (field.type === "expandable") {
         return hass.localize(
-          `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.sections.${field.name}.description`
+          `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.step.${step.step_id}.sections.${field.name}.description`,
+          step.description_placeholders
         );
       }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Extend usage of `description_placeholders` for Config / Options / Subentry flows forms string interpolation to field labels.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
