### PR TITLE
Use new entity naming in statistic picker

### DIFF
--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -1,29 +1,55 @@
+import { mdiChartLine } from "@mdi/js";
 import type { ComboBoxLitRenderer } from "@vaadin/combo-box/lit";
+import Fuse, { type IFuseOptions } from "fuse.js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues, TemplateResult } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../common/array/ensure-array";
 import { fireEvent } from "../../common/dom/fire_event";
-import { stringCompare } from "../../common/string/compare";
-import type { ScorableTextItem } from "../../common/string/filter/sequence-matching";
-import { fuzzyFilterSort } from "../../common/string/filter/sequence-matching";
+import { computeAreaName } from "../../common/entity/compute_area_name";
+import { computeDeviceName } from "../../common/entity/compute_device_name";
+import { computeEntityName } from "../../common/entity/compute_entity_name";
+import { computeStateName } from "../../common/entity/compute_state_name";
+import { getEntityContext } from "../../common/entity/get_entity_context";
+import { caseInsensitiveStringCompare } from "../../common/string/compare";
+import { computeRTL } from "../../common/util/compute_rtl";
 import type { StatisticsMetaData } from "../../data/recorder";
 import { getStatisticIds, getStatisticLabel } from "../../data/recorder";
 import type { HomeAssistant, ValueChangedEvent } from "../../types";
-import { documentationUrl } from "../../util/documentation-url";
 import "../ha-combo-box";
 import type { HaComboBox } from "../ha-combo-box";
 import "../ha-combo-box-item";
 import "../ha-svg-icon";
 import "./state-badge";
+import { domainToName } from "../../data/integration";
 
-interface StatisticItem extends ScorableTextItem {
+type StatisticItemType = "entity" | "external" | "no_state";
+
+interface StatisticItem {
   id: string;
-  name: string;
+  label: string;
+  primary: string;
+  secondary?: string;
+  show_entity_id?: boolean;
+  entity_name?: string;
+  area_name?: string;
+  device_name?: string;
+  friendly_name?: string;
+  sorting_label?: string;
   state?: HassEntity;
+  type?: StatisticItemType;
+  iconPath?: string;
 }
+
+const TYPE_ORDER = ["entity", "external", "no_state"] as StatisticItemType[];
+
+const ENTITY_ID_STYLE = styleMap({
+  fontFamily: "var(--code-font-family, monospace)",
+  fontSize: "11px",
+});
 
 @customElement("ha-statistic-picker")
 export class HaStatisticPicker extends LitElement {
@@ -88,44 +114,56 @@ export class HaStatisticPicker extends LitElement {
   @property({ attribute: false }) public helpMissingEntityUrl =
     "/more-info/statistics/";
 
-  @state() private _opened?: boolean;
+  @state() private _opened = false;
 
   @query("ha-combo-box", true) public comboBox!: HaComboBox;
 
-  private _init = false;
+  private _initialItems = false;
 
-  private _statistics: StatisticItem[] = [];
+  private _items: StatisticItem[] = [];
 
-  @state() private _filteredItems?: StatisticItem[] = undefined;
+  protected firstUpdated(changedProperties: PropertyValues): void {
+    super.firstUpdated(changedProperties);
+    this.hass.loadBackendTranslation("title");
+  }
 
-  private _rowRenderer: ComboBoxLitRenderer<StatisticItem> = (item) =>
-    html`<ha-combo-box-item type="button">
-      ${item.state
-        ? html`
+  private _rowRenderer: ComboBoxLitRenderer<StatisticItem> = (
+    item,
+    { index }
+  ) => html`
+    <ha-combo-box-item type="button" compact .borderTop=${index !== 0}>
+      ${!item.state
+        ? html`<ha-svg-icon
+            style="margin: 0 4px"
+            slot="start"
+            .path=${item.iconPath}
+          ></ha-svg-icon>`
+        : html`
             <state-badge
               slot="start"
               .stateObj=${item.state}
               .hass=${this.hass}
             ></state-badge>
-          `
-        : html`<span slot="start" style="width: 32px"></span>`}
-      <span slot="headline">${item.name}</span>
-      <span slot="supporting-text"
-        >${item.id === "" || item.id === "__missing"
-          ? html`<a
-              target="_blank"
-              rel="noopener noreferrer"
-              href=${documentationUrl(this.hass, this.helpMissingEntityUrl)}
-              >${this.hass.localize(
-                "ui.components.statistic-picker.learn_more"
-              )}</a
-            >`
-          : item.id}</span
-      >
-    </ha-combo-box-item>`;
+          `}
 
-  private _getStatistics = memoizeOne(
+      <span slot="headline">${item.primary} </span>
+      ${item.secondary
+        ? html`<span slot="supporting-text">${item.secondary}</span>`
+        : nothing}
+      ${item.id && item.show_entity_id
+        ? html`
+            <span slot="supporting-text" style=${ENTITY_ID_STYLE}>
+              ${item.id}
+            </span>
+          `
+        : nothing}
+    </ha-combo-box-item>
+  `;
+
+  private _getItems = memoizeOne(
     (
+      _opened: boolean,
+      hass: this["hass"],
       statisticIds: StatisticsMetaData[],
       includeStatisticsUnitOfMeasurement?: string | string[],
       includeUnitClass?: string | string[],
@@ -138,10 +176,12 @@ export class HaStatisticPicker extends LitElement {
         return [
           {
             id: "",
-            name: this.hass.localize(
+            label: this.hass.localize(
               "ui.components.statistic-picker.no_statistics"
             ),
-            strings: [],
+            primary: this.hass.localize(
+              "ui.components.statistic-picker.no_statistics"
+            ),
           },
         ];
       }
@@ -175,6 +215,8 @@ export class HaStatisticPicker extends LitElement {
         });
       }
 
+      const isRTL = computeRTL(this.hass);
+
       const output: StatisticItem[] = [];
       statisticIds.forEach((meta) => {
         if (
@@ -188,22 +230,67 @@ export class HaStatisticPicker extends LitElement {
         if (!entityState) {
           if (!entitiesOnly) {
             const id = meta.statistic_id;
-            const name = getStatisticLabel(this.hass, meta.statistic_id, meta);
-            output.push({
-              id,
-              name,
-              strings: [id, name],
-            });
+            const label = getStatisticLabel(this.hass, meta.statistic_id, meta);
+            const type =
+              meta.statistic_id.includes(":") &&
+              !meta.statistic_id.includes(".")
+                ? "external"
+                : "no_state";
+
+            if (type === "no_state") {
+              output.push({
+                id,
+                primary: label,
+                secondary: this.hass.localize(
+                  "ui.components.statistic-picker.no_state"
+                ),
+                label,
+                type,
+                sorting_label: label,
+              });
+            } else if (type === "external") {
+              const domain = id.split(":")[0];
+              const domainName = domainToName(this.hass.localize, domain);
+              output.push({
+                id,
+                primary: label,
+                secondary: domainName,
+                label,
+                type,
+                sorting_label: label,
+                iconPath: mdiChartLine,
+              });
+            }
           }
           return;
         }
         const id = meta.statistic_id;
-        const name = getStatisticLabel(this.hass, meta.statistic_id, meta);
+
+        const { area, device } = getEntityContext(entityState, hass);
+
+        const friendlyName = computeStateName(entityState); // Keep this for search
+        const entityName = computeEntityName(entityState, hass);
+        const deviceName = device ? computeDeviceName(device) : undefined;
+        const areaName = area ? computeAreaName(area) : undefined;
+
+        const primary = entityName || deviceName || id;
+        const secondary = [areaName, entityName ? deviceName : undefined]
+          .filter(Boolean)
+          .join(isRTL ? " ◂ " : " ▸ ");
+
         output.push({
           id,
-          name,
+          primary,
+          secondary,
+          label: friendlyName,
           state: entityState,
-          strings: [id, name],
+          type: "entity",
+          sorting_label: [deviceName, entityName].join("_"),
+          entity_name: entityName || deviceName,
+          area_name: areaName,
+          device_name: deviceName,
+          friendly_name: friendlyName,
+          show_entity_id: hass.userData?.showEntityIdPicker,
         });
       });
 
@@ -211,36 +298,62 @@ export class HaStatisticPicker extends LitElement {
         return [
           {
             id: "",
-            name: this.hass.localize("ui.components.statistic-picker.no_match"),
-            strings: [],
+            primary: this.hass.localize(
+              "ui.components.statistic-picker.no_match"
+            ),
+            label: this.hass.localize(
+              "ui.components.statistic-picker.no_match"
+            ),
           },
         ];
       }
 
       if (output.length > 1) {
-        output.sort((a, b) =>
-          stringCompare(a.name || "", b.name || "", this.hass.locale.language)
-        );
+        output.sort((a, b) => {
+          const aPrefix = TYPE_ORDER.indexOf(a.type || "no_state");
+          const bPrefix = TYPE_ORDER.indexOf(b.type || "no_state");
+
+          return caseInsensitiveStringCompare(
+            `${aPrefix}_${a.sorting_label || ""}`,
+            `${bPrefix}_${b.sorting_label || ""}`,
+            this.hass.locale.language
+          );
+        });
       }
 
       output.push({
         id: "__missing",
-        name: this.hass.localize(
+        primary: this.hass.localize(
           "ui.components.statistic-picker.missing_entity"
         ),
-        strings: [],
+        label: this.hass.localize(
+          "ui.components.statistic-picker.missing_entity"
+        ),
       });
 
       return output;
     }
   );
 
-  public open() {
-    this.comboBox?.open();
+  public async open() {
+    await this.updateComplete;
+    await this.comboBox?.open();
   }
 
-  public focus() {
-    this.comboBox?.focus();
+  public async focus() {
+    await this.updateComplete;
+    await this.comboBox?.focus();
+  }
+
+  protected shouldUpdate(changedProps: PropertyValues) {
+    if (
+      changedProps.has("value") ||
+      changedProps.has("label") ||
+      changedProps.has("disabled")
+    ) {
+      return true;
+    }
+    return !(!changedProps.has("_opened") && this._opened);
   }
 
   public willUpdate(changedProps: PropertyValues) {
@@ -250,39 +363,28 @@ export class HaStatisticPicker extends LitElement {
     ) {
       this._getStatisticIds();
     }
-    if (
-      (!this._init && this.statisticIds) ||
-      (changedProps.has("_opened") && this._opened)
-    ) {
-      this._init = true;
-      if (this.hasUpdated) {
-        this._statistics = this._getStatistics(
-          this.statisticIds!,
-          this.includeStatisticsUnitOfMeasurement,
-          this.includeUnitClass,
-          this.includeDeviceClass,
-          this.entitiesOnly,
-          this.excludeStatistics,
-          this.value
-        );
-      } else {
-        this.updateComplete.then(() => {
-          this._statistics = this._getStatistics(
-            this.statisticIds!,
-            this.includeStatisticsUnitOfMeasurement,
-            this.includeUnitClass,
-            this.includeDeviceClass,
-            this.entitiesOnly,
-            this.excludeStatistics,
-            this.value
-          );
-        });
+
+    if (!this._initialItems || (changedProps.has("_opened") && this._opened)) {
+      this._items = this._getItems(
+        this._opened,
+        this.hass,
+        this.statisticIds!,
+        this.includeStatisticsUnitOfMeasurement,
+        this.includeUnitClass,
+        this.includeDeviceClass,
+        this.entitiesOnly,
+        this.excludeStatistics,
+        this.value
+      );
+      if (this._initialItems) {
+        this.comboBox.filteredItems = this._items;
       }
+      this._initialItems = true;
     }
   }
 
   protected render(): TemplateResult | typeof nothing {
-    if (this._statistics.length === 0) {
+    if (this._items.length === 0) {
       return nothing;
     }
 
@@ -296,11 +398,10 @@ export class HaStatisticPicker extends LitElement {
         .renderer=${this._rowRenderer}
         .disabled=${this.disabled}
         .allowCustomValue=${this.allowCustomEntity}
-        .items=${this._statistics}
-        .filteredItems=${this._filteredItems ?? this._statistics}
+        .filteredItems=${this._items}
         item-value-path="id"
         item-id-path="id"
-        item-label-path="name"
+        item-label-path="label"
         @opened-changed=${this._openedChanged}
         @value-changed=${this._statisticChanged}
         @filter-changed=${this._filterChanged}
@@ -332,11 +433,49 @@ export class HaStatisticPicker extends LitElement {
     this._opened = ev.detail.value;
   }
 
+  private _fuseKeys = [
+    "label",
+    "entity_name",
+    "device_name",
+    "area_name",
+    "friendly_name", // for backwards compatibility
+    "id", // for technical search
+  ];
+
+  private _fuseIndex = memoizeOne((states: StatisticItem[]) =>
+    Fuse.createIndex(this._fuseKeys, states)
+  );
+
   private _filterChanged(ev: CustomEvent): void {
-    const filterString = ev.detail.value.toLowerCase();
-    this._filteredItems = filterString.length
-      ? fuzzyFilterSort<StatisticItem>(filterString, this._statistics)
-      : undefined;
+    const target = ev.target as HaComboBox;
+    const filterString = ev.detail.value.trim().toLowerCase() as string;
+
+    const minLength = 2;
+
+    const searchTerms = (filterString.split(" ") ?? []).filter(
+      (term) => term.length >= minLength
+    );
+
+    if (searchTerms.length > 0) {
+      const index = this._fuseIndex(this._items);
+
+      const options: IFuseOptions<StatisticItem> = {
+        isCaseSensitive: false,
+        threshold: 0.3,
+        ignoreDiacritics: true,
+        minMatchCharLength: minLength,
+      };
+
+      const fuse = new Fuse(this._items, options, index);
+      const results = fuse.search({
+        $and: searchTerms.map((term) => ({
+          $or: this._fuseKeys.map((key) => ({ [key]: term })),
+        })),
+      });
+      target.filteredItems = results.map((result) => result.item);
+    } else {
+      target.filteredItems = this._items;
+    }
   }
 
   private _setValue(value: string) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -722,6 +722,7 @@
         "statistic": "Statistic",
         "no_statistics": "You don't have any statistics",
         "no_match": "No matching statistics found",
+        "no_state": "Entity without state",
         "missing_entity": "Why is my entity not listed?",
         "learn_more": "Learn more about statistics"
       },


### PR DESCRIPTION
## Proposed change

Similar to https://github.com/home-assistant/frontend/pull/24971 but for statistic picker.

Statistic picker can display 3 type of elements so we have to adapt the displayed info according to the type
- regular sensor (blue on the screenshot) : same display as entity picker
- external statistic (red on the screenshot) : first line : statistic label / second line : integration name
- orphan statistic (green on the screenshot) : first line : statistic id / second line : fixed label

An chart icon is now displayed for external statistic instead of empty icon.

![CleanShot 2025-04-22 at 18 58 17](https://github.com/user-attachments/assets/4494a4b6-0c33-469f-b828-c5385892a451)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
