### PR TITLE
Centralize energy usage calculations

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1028,11 +1028,7 @@ export const computeConsumptionSingle = (data: {
   }
 
   if (from_battery != null) {
-    if (to_grid != null) {
-      used_battery = (from_battery || 0) - (battery_to_grid || 0);
-    } else {
-      used_battery = from_battery;
-    }
+    used_battery = (from_battery || 0) - (battery_to_grid || 0);
   }
 
   if (from_grid != null) {

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -802,6 +802,8 @@ export interface EnergyConsumptionData {
   used_total: Record<number, number>;
   grid_to_battery: Record<number, number>;
   battery_to_grid: Record<number, number>;
+  solar_to_battery: Record<number, number>;
+  solar_to_grid: Record<number, number>;
   used_solar: Record<number, number>;
   used_grid: Record<number, number>;
   used_battery: Record<number, number>;
@@ -809,6 +811,8 @@ export interface EnergyConsumptionData {
     used_total: number;
     grid_to_battery: number;
     battery_to_grid: number;
+    solar_to_battery: number;
+    solar_to_grid: number;
     used_solar: number;
     used_grid: number;
     used_battery: number;
@@ -937,6 +941,8 @@ const computeConsumptionDataPartial = (
     used_total: {},
     grid_to_battery: {},
     battery_to_grid: {},
+    solar_to_battery: {},
+    solar_to_grid: {},
     used_solar: {},
     used_grid: {},
     used_battery: {},
@@ -944,6 +950,8 @@ const computeConsumptionDataPartial = (
       used_total: 0,
       grid_to_battery: 0,
       battery_to_grid: 0,
+      solar_to_battery: 0,
+      solar_to_grid: 0,
       used_solar: 0,
       used_grid: 0,
       used_battery: 0,
@@ -966,6 +974,8 @@ const computeConsumptionDataPartial = (
       used_solar,
       used_grid,
       used_battery,
+      solar_to_battery,
+      solar_to_grid,
     } = computeConsumptionSingle({
       from_grid: data.from_grid && (data.from_grid[t] ?? 0),
       to_grid: data.to_grid && (data.to_grid[t] ?? 0),
@@ -984,6 +994,10 @@ const computeConsumptionDataPartial = (
     outData.total.used_grid += used_grid;
     outData.used_solar![t] = used_solar;
     outData.total.used_solar += used_solar;
+    outData.solar_to_battery[t] = solar_to_battery;
+    outData.total.solar_to_battery += solar_to_battery;
+    outData.solar_to_grid[t] = solar_to_grid;
+    outData.total.solar_to_grid += solar_to_grid;
   });
 
   return outData;
@@ -998,6 +1012,8 @@ export const computeConsumptionSingle = (data: {
 }): {
   grid_to_battery: number;
   battery_to_grid: number;
+  solar_to_battery: number;
+  solar_to_grid: number;
   used_solar: number;
   used_grid: number;
   used_battery: number;
@@ -1011,6 +1027,8 @@ export const computeConsumptionSingle = (data: {
   let used_solar = 0;
   let grid_to_battery = 0;
   let battery_to_grid = 0;
+  let solar_to_battery = 0;
+  let solar_to_grid = 0;
   let used_battery = 0;
   let used_grid = 0;
   if ((to_grid != null || to_battery != null) && solar != null) {
@@ -1028,14 +1046,19 @@ export const computeConsumptionSingle = (data: {
   }
 
   if (from_battery != null) {
-    used_battery = (from_battery || 0) - (battery_to_grid || 0);
+    used_battery = (from_battery || 0) - battery_to_grid;
   }
 
   if (from_grid != null) {
+    used_grid = from_grid - grid_to_battery;
+  }
+
+  if (solar != null) {
     if (to_battery != null) {
-      used_grid = from_grid - grid_to_battery;
-    } else {
-      used_grid = from_grid;
+      solar_to_battery = Math.max(0, (to_battery || 0) - grid_to_battery);
+    }
+    if (to_grid != null) {
+      solar_to_grid = Math.max(0, (to_grid || 0) - battery_to_grid);
     }
   }
 
@@ -1045,6 +1068,8 @@ export const computeConsumptionSingle = (data: {
     used_battery,
     grid_to_battery,
     battery_to_grid,
+    solar_to_battery,
+    solar_to_grid,
   };
 };
 

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -347,12 +347,13 @@ export class HuiEnergyDevicesDetailGraphCard
     );
 
     const untrackedConsumption: BarSeriesOption["data"] = [];
-    Object.keys(consumptionData.total)
+    Object.keys(consumptionData.used_total)
       .sort((a, b) => Number(a) - Number(b))
       .forEach((time) => {
         const ts = Number(time);
         const value =
-          consumptionData.total[time] - (totalDeviceConsumption[time] || 0);
+          consumptionData.used_total[time] -
+          (totalDeviceConsumption[time] || 0);
         const dataPoint: number[] = [ts, value];
         if (compare) {
           dataPoint[2] = dataPoint[0];

--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -169,18 +169,12 @@ class HuiEnergyDistrubutionCard
     }
 
     let solarToBattery: null | number = null;
+    let solarToGrid: null | number = null;
+    if (hasSolarProduction) {
+      solarToGrid = consumption.total.solar_to_grid;
+    }
     if (hasSolarProduction && hasBattery) {
-      solarToBattery = 0;
-      summedData.timestamps.forEach((t) => {
-        solarToBattery! += Math.max(
-          Math.min(
-            summedData.solar![t] || 0,
-            (summedData.to_battery![t] || 0) -
-              (consumption.grid_to_battery![t] || 0)
-          ),
-          0
-        );
-      });
+      solarToBattery = consumption.total.solar_to_battery;
     }
 
     let batteryConsumption: number | null = null;
@@ -250,7 +244,7 @@ class HuiEnergyDistrubutionCard
     const totalLines =
       gridConsumption +
       (solarConsumption || 0) +
-      (returnedToGrid ? returnedToGrid - (batteryToGrid || 0) : 0) +
+      (solarToGrid || 0) +
       (solarToBattery || 0) +
       (batteryConsumption || 0) +
       (batteryFromGrid || 0) +
@@ -650,18 +644,14 @@ class HuiEnergyDistrubutionCard
                 d="M0,${hasBattery ? 50 : hasSolarProduction ? 56 : 53} H100"
                 vector-effect="non-scaling-stroke"
               ></path>
-              ${returnedToGrid && hasSolarProduction && this._animate
+              ${solarToGrid && this._animate
                 ? svg`<circle
                     r="1"
                     class="return"
                     vector-effect="non-scaling-stroke"
                   >
                     <animateMotion
-                      dur="${
-                        6 -
-                        ((returnedToGrid - (batteryToGrid || 0)) / totalLines) *
-                          6
-                      }s"
+                      dur="${6 - (solarToGrid / totalLines) * 6}s"
                       repeatCount="indefinite"
                       calcMode="linear"
                     >

--- a/src/panels/lovelace/cards/energy/hui-energy-self-sufficiency-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-self-sufficiency-gauge-card.ts
@@ -10,6 +10,7 @@ import "../../../../components/ha-svg-icon";
 import "../../../../components/ha-tooltip";
 import type { EnergyData } from "../../../../data/energy";
 import {
+  computeConsumptionData,
   getEnergyDataCollection,
   getSummedData,
 } from "../../../../data/energy";
@@ -76,70 +77,14 @@ class HuiEnergySelfSufficiencyGaugeCard
 
     // The strategy only includes this card if we have a grid.
     const { summedData, compareSummedData: _ } = getSummedData(this._data);
-
-    const hasSolarProduction = summedData.solar !== undefined;
-    const hasBattery =
-      summedData.to_battery !== undefined ||
-      summedData.from_battery !== undefined;
-    const hasReturnToGrid = summedData.to_grid !== undefined;
+    const { consumption, compareConsumption: __ } = computeConsumptionData(
+      summedData,
+      undefined
+    );
 
     const totalFromGrid = summedData.total.from_grid ?? 0;
 
-    let totalSolarProduction: number | null = null;
-
-    if (hasSolarProduction) {
-      totalSolarProduction = summedData.total.solar ?? 0;
-    }
-
-    let totalBatteryIn: number | null = null;
-    let totalBatteryOut: number | null = null;
-
-    if (hasBattery) {
-      totalBatteryIn = summedData.total.to_battery ?? 0;
-      totalBatteryOut = summedData.total.from_battery ?? 0;
-    }
-
-    let returnedToGrid: number | null = null;
-
-    if (hasReturnToGrid) {
-      returnedToGrid = summedData.total.to_grid ?? 0;
-    }
-
-    let solarConsumption: number | null = null;
-    if (hasSolarProduction) {
-      solarConsumption =
-        (totalSolarProduction || 0) -
-        (returnedToGrid || 0) -
-        (totalBatteryIn || 0);
-    }
-
-    let batteryFromGrid: null | number = null;
-    let batteryToGrid: null | number = null;
-    if (solarConsumption !== null && solarConsumption < 0) {
-      // What we returned to the grid and what went in to the battery is more than produced,
-      // so we have used grid energy to fill the battery
-      // or returned battery energy to the grid
-      if (hasBattery) {
-        batteryFromGrid = solarConsumption * -1;
-        if (batteryFromGrid > totalFromGrid) {
-          batteryToGrid = batteryFromGrid - totalFromGrid;
-          batteryFromGrid = totalFromGrid;
-        }
-      }
-      solarConsumption = 0;
-    }
-
-    let batteryConsumption: number | null = null;
-    if (hasBattery) {
-      batteryConsumption = (totalBatteryOut || 0) - (batteryToGrid || 0);
-    }
-
-    const gridConsumption = Math.max(0, totalFromGrid - (batteryFromGrid || 0));
-
-    const totalHomeConsumption = Math.max(
-      0,
-      gridConsumption + (solarConsumption || 0) + (batteryConsumption || 0)
-    );
+    const totalHomeConsumption = Math.max(0, consumption.total.used_total);
 
     let value: number | undefined;
     if (
@@ -147,7 +92,7 @@ class HuiEnergySelfSufficiencyGaugeCard
       totalHomeConsumption !== null &&
       totalHomeConsumption > 0
     ) {
-      value = (1 - totalFromGrid / totalHomeConsumption) * 100;
+      value = (1 - Math.min(1, totalFromGrid / totalHomeConsumption)) * 100;
     }
 
     return html`

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -14,8 +14,13 @@ import { getEnergyColor } from "./common/color";
 import { formatNumber } from "../../../../common/number/format_number";
 import "../../../../components/chart/ha-chart-base";
 import "../../../../components/ha-card";
-import type { EnergyData, EnergySumData } from "../../../../data/energy";
+import type {
+  EnergyData,
+  EnergySumData,
+  EnergyConsumptionData,
+} from "../../../../data/energy";
 import {
+  computeConsumptionData,
   getEnergyDataCollection,
   getSummedData,
 } from "../../../../data/energy";
@@ -283,6 +288,10 @@ export class HuiEnergyUsageGraphCard
     this._compareEnd = energyData.endCompare;
 
     const { summedData, compareSummedData } = getSummedData(energyData);
+    const { consumption, compareConsumption } = computeConsumptionData(
+      summedData,
+      compareSummedData
+    );
 
     if (energyData.statsCompare) {
       datasets.push(
@@ -290,6 +299,7 @@ export class HuiEnergyUsageGraphCard
           energyData.statsCompare,
           energyData.statsMetadata,
           compareSummedData!,
+          compareConsumption!,
           statIds,
           colorIndices,
           computedStyles,
@@ -315,6 +325,7 @@ export class HuiEnergyUsageGraphCard
         energyData.stats,
         energyData.statsMetadata,
         summedData,
+        consumption,
         statIds,
         colorIndices,
         computedStyles,
@@ -333,6 +344,7 @@ export class HuiEnergyUsageGraphCard
     statistics: Statistics,
     statisticsMetaData: Record<string, StatisticsMetaData>,
     summedData: EnergySumData,
+    consumptionData: EnergyConsumptionData,
     statIdsByCat: {
       to_grid?: string[] | undefined;
       from_grid?: string[] | undefined;
@@ -361,8 +373,7 @@ export class HuiEnergyUsageGraphCard
     } = {};
 
     Object.entries(statIdsByCat).forEach(([key, statIds]) => {
-      const add = !["solar", "from_battery"].includes(key);
-      if (!add) {
+      if (!["to_grid", "from_grid", "to_battery"].includes(key)) {
         return;
       }
       const sets: Record<string, Record<number, number>> = {};
@@ -387,47 +398,22 @@ export class HuiEnergyUsageGraphCard
       combinedData[key] = sets;
     });
 
-    const grid_to_battery = {};
-    const battery_to_grid = {};
-    if ((summedData.to_grid || summedData.to_battery) && summedData.solar) {
-      const used_solar = {};
-      for (const start of Object.keys(summedData.solar)) {
-        used_solar[start] =
-          (summedData.solar[start] || 0) -
-          (summedData.to_grid?.[start] || 0) -
-          (summedData.to_battery?.[start] || 0);
-        if (used_solar[start] < 0) {
-          if (summedData.to_battery) {
-            grid_to_battery[start] = used_solar[start] * -1;
-            if (grid_to_battery[start] > (summedData.from_grid?.[start] || 0)) {
-              battery_to_grid[start] =
-                grid_to_battery[start] - (summedData.from_grid?.[start] || 0);
-              grid_to_battery[start] = summedData.from_grid?.[start];
-            }
-          }
-          used_solar[start] = 0;
-        }
-      }
-      combinedData.used_solar = { used_solar };
-    }
-
-    if (summedData.from_battery) {
-      if (summedData.to_grid) {
-        const used_battery = {};
-        for (const start of Object.keys(summedData.from_battery)) {
-          used_battery[start] =
-            (summedData.from_battery![start] || 0) -
-            (battery_to_grid[start] || 0);
-        }
-        combinedData.used_battery = { used_battery };
-      } else {
-        combinedData.used_battery = { used_battery: summedData.from_battery };
-      }
-    }
+    combinedData.used_solar = { used_solar: consumptionData.used_solar };
+    combinedData.used_battery = {
+      used_battery: consumptionData.used_battery,
+    };
 
     if (combinedData.from_grid && summedData.to_battery) {
       const used_grid = {};
-      for (const start of Object.keys(grid_to_battery)) {
+      // If we have to_battery and multiple grid sources in the same period, we
+      // can't determine which source was used. So delete all the individual
+      // sources and replace with a 'combined from grid' value.
+      for (const [start, grid_to_battery] of Object.entries(
+        consumptionData.grid_to_battery
+      )) {
+        if (!grid_to_battery) {
+          continue;
+        }
         let noOfSources = 0;
         let source: string;
         for (const [key, stats] of Object.entries(combinedData.from_grid)) {
@@ -440,30 +426,19 @@ export class HuiEnergyUsageGraphCard
           }
         }
         if (noOfSources === 1) {
-          combinedData.from_grid[source!][start] -= grid_to_battery[start] || 0;
+          combinedData.from_grid[source!][start] =
+            consumptionData.used_grid[start];
         } else {
-          let total_from_grid = 0;
           Object.values(combinedData.from_grid).forEach((stats) => {
-            total_from_grid += stats[start] || 0;
             delete stats[start];
           });
-          used_grid[start] = total_from_grid - (grid_to_battery[start] || 0);
+          used_grid[start] = consumptionData.used_grid[start];
         }
       }
       combinedData.used_grid = { used_grid };
     }
 
-    let allKeys: string[] = [];
-
-    Object.values(combinedData).forEach((sources) => {
-      Object.values(sources).forEach((source) => {
-        allKeys = allKeys.concat(Object.keys(source));
-      });
-    });
-
-    const uniqueKeys = Array.from(new Set(allKeys)).sort(
-      (a, b) => Number(a) - Number(b)
-    );
+    const uniqueKeys = summedData.timestamps;
 
     const compareTransform = getCompareTransform(
       this._start,
@@ -477,14 +452,14 @@ export class HuiEnergyUsageGraphCard
         for (const key of uniqueKeys) {
           const value = source[key] || 0;
           const dataPoint = [
-            Number(key),
+            new Date(key),
             value && ["to_grid", "to_battery"].includes(type)
               ? -1 * value
               : value,
           ];
           if (compare) {
             dataPoint[2] = dataPoint[0];
-            dataPoint[0] = compareTransform(dataPoint[0]);
+            dataPoint[0] = compareTransform(dataPoint[0] as Date);
           }
           points.push(dataPoint);
         }

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -101,6 +101,8 @@ describe("Energy Usage Calculation Tests", () => {
           used_solar: 0,
           used_grid: x,
           used_battery: 0,
+          solar_to_battery: 0,
+          solar_to_grid: 0,
         }
       );
     });
@@ -121,6 +123,8 @@ describe("Energy Usage Calculation Tests", () => {
           used_solar: Math.max(0, s - 3),
           used_grid: 0,
           used_battery: 0,
+          solar_to_battery: 0,
+          solar_to_grid: 3,
         }
       );
     });
@@ -150,6 +154,8 @@ describe("Energy Usage Calculation Tests", () => {
           used_solar: Math.max(0, 7 - to_grid),
           used_grid: from_grid,
           used_battery: 0,
+          solar_to_battery: 0,
+          solar_to_grid: to_grid,
         }
       );
     });
@@ -169,6 +175,8 @@ describe("Energy Usage Calculation Tests", () => {
         used_solar: 0,
         used_grid: 2,
         used_battery: 0,
+        solar_to_battery: 0,
+        solar_to_grid: 0,
       }
     );
   });
@@ -187,6 +195,8 @@ describe("Energy Usage Calculation Tests", () => {
         used_solar: 0,
         used_grid: 5,
         used_battery: 5,
+        solar_to_battery: 0,
+        solar_to_grid: 0,
       }
     );
   });
@@ -205,6 +215,8 @@ describe("Energy Usage Calculation Tests", () => {
         used_solar: 0,
         used_grid: 0,
         used_battery: 1,
+        solar_to_battery: 0,
+        solar_to_grid: 0,
       }
     );
   });
@@ -282,6 +294,8 @@ describe("Energy Usage Calculation Tests", () => {
         used_solar: 1,
         used_grid: 5,
         used_battery: 0,
+        solar_to_battery: 3,
+        solar_to_grid: 3,
       }
     );
     assert.deepEqual(
@@ -298,6 +312,8 @@ describe("Energy Usage Calculation Tests", () => {
         used_solar: 1,
         used_grid: 5,
         used_battery: 10,
+        solar_to_battery: 3,
+        solar_to_grid: 3,
       }
     );
     assert.deepEqual(
@@ -314,6 +330,8 @@ describe("Energy Usage Calculation Tests", () => {
         used_solar: 0,
         used_grid: 1,
         used_battery: 1,
+        solar_to_battery: 0,
+        solar_to_grid: 7,
       }
     );
     assert.deepEqual(
@@ -330,6 +348,8 @@ describe("Energy Usage Calculation Tests", () => {
         used_solar: 1,
         used_grid: 2,
         used_battery: 1,
+        solar_to_battery: 1,
+        solar_to_grid: 7,
       }
     );
     /* Test does not pass

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -8,7 +8,10 @@ import {
   DateFormat,
   TimeZone,
 } from "../../src/data/translation";
-import { formatConsumptionShort } from "../../src/data/energy";
+import {
+  computeConsumptionSingle,
+  formatConsumptionShort,
+} from "../../src/data/energy";
 import type { HomeAssistant } from "../../src/types";
 
 describe("Energy Short Format Test", () => {
@@ -78,5 +81,168 @@ describe("Energy Short Format Test", () => {
       formatConsumptionShort(hass, -1234.56, "kWh"),
       "-1,234.56 kWh"
     );
+  });
+});
+
+describe("Energy Usage Calculation Tests", () => {
+  it("Grid consumption only", () => {
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 0,
+        to_grid: undefined,
+        solar: undefined,
+        to_battery: undefined,
+        from_battery: undefined,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 0,
+        used_solar: 0,
+        used_grid: 0,
+        used_battery: 0,
+      }
+    );
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: undefined,
+        solar: undefined,
+        to_battery: undefined,
+        from_battery: undefined,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 0,
+        used_solar: 0,
+        used_grid: 5,
+        used_battery: 0,
+      }
+    );
+  });
+  it("Solar production", () => {
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 0,
+        to_grid: 3,
+        solar: 7,
+        to_battery: undefined,
+        from_battery: undefined,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 0,
+        used_solar: 4,
+        used_grid: 0,
+        used_battery: 0,
+      }
+    );
+  });
+  it("Grid and solar consumption", () => {
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 3,
+        solar: 7,
+        to_battery: undefined,
+        from_battery: undefined,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 0,
+        used_solar: 4,
+        used_grid: 5,
+        used_battery: 0,
+      }
+    );
+  });
+  it("Grid and battery", () => {
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 0,
+        solar: 0,
+        to_battery: 3,
+        from_battery: 0,
+      }),
+      {
+        grid_to_battery: 3,
+        battery_to_grid: 0,
+        used_solar: 0,
+        used_grid: 2,
+        used_battery: 0,
+      }
+    );
+    /* Test does not pass, battery is not really correct when solar is not present
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 0,
+        solar: undefined,
+        to_battery: 3,
+        from_battery: 0,
+      }),
+      {
+        grid_to_battery: 3,
+        battery_to_grid: 0,
+        used_solar: 0,
+        used_grid: 2,
+        used_battery: 0,
+      }
+    );
+    */
+    /* Test does not pass
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 4,
+        solar: 0,
+        to_battery: 0,
+        from_battery: 4,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 4,
+        used_solar: 0,
+        used_grid: 5,
+        used_battery: 0,
+      }
+    );
+    */
+  });
+  it("Grid, solar, and battery", () => {
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 3,
+        solar: 7,
+        to_battery: 3,
+        from_battery: 0,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 0,
+        used_solar: 1,
+        used_grid: 5,
+        used_battery: 0,
+      }
+    );
+    /* Test does not pass
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 3,
+        solar: 1,
+        to_battery: 0,
+        from_battery: 2,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 2,
+        used_solar: 0,
+        used_grid: 5,
+        used_battery: 0,
+      }
+    );
+    */
   });
 });

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -172,6 +172,39 @@ describe("Energy Usage Calculation Tests", () => {
         used_battery: 0,
       }
     );
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 0,
+        solar: 0,
+        to_battery: 0,
+        from_battery: 5,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 0,
+        used_solar: 0,
+        used_grid: 5,
+        used_battery: 5,
+      }
+    );
+    /* Fails
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 1,
+        solar: 0,
+        to_battery: 3,
+        from_battery: 1,
+      }),
+      {
+        grid_to_battery: 3,
+        battery_to_grid: 1,
+        used_solar: 0,
+        used_grid: 1,
+        used_battery: 0,
+      }
+    ); */
     /* Test does not pass, battery is not really correct when solar is not present
     assert.deepEqual(
       computeConsumptionSingle({
@@ -224,6 +257,54 @@ describe("Energy Usage Calculation Tests", () => {
         used_solar: 1,
         used_grid: 5,
         used_battery: 0,
+      }
+    );
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 5,
+        to_grid: 3,
+        solar: 7,
+        to_battery: 3,
+        from_battery: 10,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 0,
+        used_solar: 1,
+        used_grid: 5,
+        used_battery: 10,
+      }
+    );
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 2,
+        to_grid: 7,
+        solar: 7,
+        to_battery: 1,
+        from_battery: 1,
+      }),
+      {
+        grid_to_battery: 1,
+        battery_to_grid: 0,
+        used_solar: 0,
+        used_grid: 1,
+        used_battery: 1,
+      }
+    );
+    assert.deepEqual(
+      computeConsumptionSingle({
+        from_grid: 2,
+        to_grid: 7,
+        solar: 9,
+        to_battery: 1,
+        from_battery: 1,
+      }),
+      {
+        grid_to_battery: 0,
+        battery_to_grid: 0,
+        used_solar: 1,
+        used_grid: 2,
+        used_battery: 1,
       }
     );
     /* Test does not pass


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
We have multiple energy cards that all try to compute things like self-consumed solar, consumed grid energy, etc. 
The cards use similar but different approaches to calculate these and sometimes up with different results that are confusingly inconsistent with each other. 

E.g.
![image](https://github.com/user-attachments/assets/31e0090d-5d06-4344-9877-4ab734415466)

1. In the hourly view, we see a lot of self-consumed solar. In the distribution view, there is no self-consumed solar.
2. The distribution view shows solar being used to charge the battery, while in the hourly view we clearly see no battery being charged from solar, it is charging from the grid.
3. While we are charging the battery from the grid, the grid_to_battery connection is broken/grayed-out in the distribution view, showing no charging dot there.

This PR will try to rectify and simplify this by performing one calculation for all the derived energy values in one common memoized function, and then let all the cards sample this data as needed. So all cards can have a consistent view of the big energy picture. 

This also makes that calculation a standalone function, so it becomes possible to write tests for it. I've wrote a few tests, but found several examples where the result did not match my expectation. I've commented out those tests for now, with a view to possibly addressing them in the future with an improved calculation. Since we can now write test cases, I think this function could be modified with more confidence that we aren't breaking other test cases, which are difficult to test live without extensive preparation. 

This change is kind of scary due to rewriting a large amount of complex calculation, but I'm hopeful it lays the groundwork for making this more maintainable going forward. 

With fixed calculations:
![image](https://github.com/user-attachments/assets/c4062af0-727d-4edf-afbf-7df955762f0e)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: 
This may address some of these issues, but is difficult to say for certain:
https://github.com/home-assistant/frontend/issues/25121
https://github.com/home-assistant/frontend/issues/24063
https://github.com/home-assistant/frontend/issues/23810
https://github.com/home-assistant/frontend/issues/21939
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
