### PR TITLE
Add context to config update entries

### DIFF
--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -6,6 +6,7 @@ import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
+import { getDeviceContext } from "../../../common/entity/get_device_context";
 import "../../../components/entity/state-badge";
 import "../../../components/ha-alert";
 import "../../../components/ha-icon-next";
@@ -76,6 +77,10 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
               ? this.getDeviceEntry(entityEntry.device_id)
               : undefined;
 
+          const areaName = deviceEntry
+            ? getDeviceContext(deviceEntry, this.hass).area?.name
+            : undefined;
+
           return html`
             <ha-md-list-item
               class=${ifDefined(
@@ -106,7 +111,7 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
                         "ui.panel.config.updates.update_in_progress"
                       )}
                     ></ha-spinner>`
-                  : ""}
+                  : nothing}
               </div>
               <span
                 >${deviceEntry
@@ -114,10 +119,11 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
                   : entity.attributes.friendly_name}</span
               >
               <span slot="supporting-text">
+                ${areaName ? html`${areaName} ⸱ ` : nothing}
                 ${entity.attributes.title} ${entity.attributes.latest_version}
                 ${entity.attributes.skipped_version
                   ? `(${this.hass.localize("ui.panel.config.updates.skipped")})`
-                  : ""}
+                  : nothing}
               </span>
               ${!this.narrow
                 ? entity.attributes.in_progress
@@ -130,7 +136,7 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
                       ></ha-spinner>
                     </div>`
                   : html`<ha-icon-next slot="end"></ha-icon-next>`
-                : ""}
+                : nothing}
             </ha-md-list-item>
           `;
         })}

--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -77,9 +77,11 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
               ? this.getDeviceEntry(entityEntry.device_id)
               : undefined;
 
-          const areaName = deviceEntry
-            ? getDeviceContext(deviceEntry, this.hass).area?.name
-            : undefined;
+          const areaName =
+            deviceEntry && deviceEntry.entry_type !== "service"
+              ? getDeviceContext(deviceEntry, this.hass).area?.name ||
+                this.hass.localize("ui.panel.config.updates.no_area")
+              : undefined;
 
           return html`
             <ha-md-list-item

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2119,7 +2119,8 @@
           "join_beta": "[%key:supervisor::system::supervisor::join_beta_action%]",
           "leave_beta": "[%key:supervisor::system::supervisor::leave_beta_action%]",
           "skipped": "Skipped",
-          "update_in_progress": "Update in progress"
+          "update_in_progress": "Update in progress",
+          "no_area": "No area"
         },
         "repairs": {
           "caption": "Repairs",


### PR DESCRIPTION
## Proposed change
- Add area context to update entries if it's not a service

![image](https://github.com/user-attachments/assets/857d1648-517d-489a-a80d-2d36c5330d10)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
