### PR TITLE
Add message when no entities found in the entity picker

### DIFF
--- a/src/components/entity/ha-entity-combo-box.ts
+++ b/src/components/entity/ha-entity-combo-box.ts
@@ -57,6 +57,7 @@ interface EntityComboBoxItem extends HassEntity {
 export type HaEntityComboBoxEntityFilterFunc = (entity: HassEntity) => boolean;
 
 const CREATE_ID = "___create-new-entity___";
+const NO_ENTITIES_ID = "___no-entities___";
 
 const DOMAIN_STYLE = styleMap({
   fontSize: "var(--ha-font-size-s)",
@@ -252,6 +253,7 @@ export class HaEntityComboBox extends LitElement {
           {
             ...FAKE_ENTITY,
             label: "",
+            entity_id: NO_ENTITIES_ID,
             primary: this.hass!.localize(
               "ui.components.entity.entity-picker.no_entities"
             ),
@@ -367,6 +369,7 @@ export class HaEntityComboBox extends LitElement {
           {
             ...FAKE_ENTITY,
             label: "",
+            entity_id: NO_ENTITIES_ID,
             primary: this.hass!.localize(
               "ui.components.entity.entity-picker.no_match"
             ),
@@ -504,6 +507,7 @@ export class HaEntityComboBox extends LitElement {
           {
             ...FAKE_ENTITY,
             label: "",
+            entity_id: NO_ENTITIES_ID,
             primary: this.hass!.localize(
               "ui.components.entity.entity-picker.no_match"
             ),

--- a/src/components/entity/ha-entity-combo-box.ts
+++ b/src/components/entity/ha-entity-combo-box.ts
@@ -499,7 +499,20 @@ export class HaEntityComboBox extends LitElement {
 
     const results = fuse.multiTermsSearch(filterString);
     if (results) {
-      target.filteredItems = results.map((result) => result.item);
+      if (results.length === 0) {
+        target.filteredItems = [
+          {
+            ...FAKE_ENTITY,
+            label: "",
+            primary: this.hass!.localize(
+              "ui.components.entity.entity-picker.no_match"
+            ),
+            icon_path: mdiMagnify,
+          },
+        ] as EntityComboBoxItem[];
+      } else {
+        target.filteredItems = results.map((result) => result.item);
+      }
     } else {
       target.filteredItems = this._items;
     }


### PR DESCRIPTION
## Proposed change

Add message when no entities found in the entity picker

![CleanShot 2025-04-29 at 14 24 36](https://github.com/user-attachments/assets/3085b694-7b1a-4ae0-adeb-65feaa9e2f70)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
