### PR TITLE
Make name a top level field for the SSDP panel

### DIFF
--- a/src/data/ssdp.ts
+++ b/src/data/ssdp.ts
@@ -7,6 +7,7 @@ import type { Store } from "home-assistant-js-websocket/dist/store";
 import type { DataTableRowData } from "../components/data-table/ha-data-table";
 
 export interface SSDPDiscoveryData extends DataTableRowData {
+  name: string | undefined;
   ssdp_usn: string;
   ssdp_st: string;
   upnp: Record<string, unknown>;

--- a/src/panels/config/integrations/integration-panels/ssdp/dialog-ssdp-discovery-info.ts
+++ b/src/panels/config/integrations/integration-panels/ssdp/dialog-ssdp-discovery-info.ts
@@ -54,6 +54,8 @@ class DialogSSDPDiscoveryInfo extends LitElement implements HassDialog {
         )}
       >
         <p>
+          <b>${this.hass.localize("ui.panel.config.ssdp.name")}</b>:
+          ${this._params.entry.name} <br />          
           <b>${this.hass.localize("ui.panel.config.ssdp.ssdp_st")}</b>:
           ${this._params.entry.ssdp_st} <br />
           <b>${this.hass.localize("ui.panel.config.ssdp.ssdp_location")}</b>:

--- a/src/panels/config/integrations/integration-panels/ssdp/dialog-ssdp-discovery-info.ts
+++ b/src/panels/config/integrations/integration-panels/ssdp/dialog-ssdp-discovery-info.ts
@@ -55,7 +55,7 @@ class DialogSSDPDiscoveryInfo extends LitElement implements HassDialog {
       >
         <p>
           <b>${this.hass.localize("ui.panel.config.ssdp.name")}</b>:
-          ${this._params.entry.name} <br />          
+          ${this._params.entry.name} <br />
           <b>${this.hass.localize("ui.panel.config.ssdp.ssdp_st")}</b>:
           ${this._params.entry.ssdp_st} <br />
           <b>${this.hass.localize("ui.panel.config.ssdp.ssdp_location")}</b>:

--- a/src/panels/config/integrations/integration-panels/ssdp/ssdp-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/ssdp/ssdp-config-panel.ts
@@ -57,14 +57,21 @@ export class SSDPConfigPanel extends SubscribeMixin(LitElement) {
   private _columns = memoizeOne(
     (localize: LocalizeFunc): DataTableColumnContainer => {
       const columns: DataTableColumnContainer<SSDPDiscoveryData> = {
-        ssdp_st: {
-          title: localize("ui.panel.config.ssdp.ssdp_st"),
+        name: {
+          title: localize("ui.panel.config.ssdp.name"),
           sortable: true,
           filterable: true,
           showNarrow: true,
           main: true,
           hideable: false,
           moveable: false,
+        },
+        ssdp_st: {
+          title: localize("ui.panel.config.ssdp.ssdp_st"),
+          sortable: true,
+          filterable: true,
+          showNarrow: true,
+          hideable: false,
           direction: "asc",
         },
         ssdp_location: {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5568,6 +5568,7 @@
           "thread_network_delete_credentials": "Delete Thread network credentials"
         },
         "ssdp": {
+          "name": "Name",
           "ssdp_st": "Search Target (ST)",
           "ssdp_location": "Device Description URL",
           "ssdp_headers": "SSDP Headers",


### PR DESCRIPTION
needs https://github.com/home-assistant/core/pull/143923

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Initial feedback on the new SSDP panel noted that it was difficult to identify devices, as the device name was buried deep in the UPnP data and not easily searchable. This change promotes the name to a top-level field in the WebSocket API response to improve discoverability and usability.
<img width="461" alt="Screenshot 2025-04-30 at 6 30 08 AM" src="https://github.com/user-attachments/assets/8202c3c6-dd80-4efe-b414-45abe582e984" />
<img width="667" alt="Screenshot 2025-04-30 at 6 29 55 AM" src="https://github.com/user-attachments/assets/5ad26423-d1ee-4106-bd51-07378ec56128" />




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
