### PR TITLE
Allow pasting more automation config formats

### DIFF
--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -27,7 +27,7 @@ import type {
   Trigger,
 } from "../../../data/automation";
 import { normalizeAutomationConfig } from "../../../data/automation";
-import type { Action } from "../../../data/script";
+import { getActionType, type Action } from "../../../data/script";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
@@ -312,10 +312,59 @@ export class HaManualAutomationEditor extends LitElement {
 
     const loaded: any = load(paste);
     if (loaded) {
-      let normalized: AutomationConfig | undefined;
+      let config = loaded;
+
+      if ("automation" in config) {
+        config = config.automation;
+        if (Array.isArray(config)) {
+          config = config[0];
+        }
+      }
+
+      if (Array.isArray(config)) {
+        if (config.length === 1) {
+          config = config[0];
+        } else {
+          const newConfig: AutomationConfig = {
+            triggers: [],
+            conditions: [],
+            actions: [],
+          };
+          let found = false;
+          config.forEach((cfg: any) => {
+            if ("trigger" in cfg) {
+              found = true;
+              (newConfig.triggers as Trigger[]).push(cfg);
+            }
+            if ("condition" in cfg) {
+              found = true;
+              (newConfig.conditions as Condition[]).push(cfg);
+            }
+            if (getActionType(cfg) !== "unknown") {
+              found = true;
+              (newConfig.actions as Action[]).push(cfg);
+            }
+          });
+          if (found) {
+            config = newConfig;
+          }
+        }
+      }
+
+      if ("trigger" in config) {
+        config = { triggers: [config] };
+      }
+      if ("condition" in config) {
+        config = { conditions: [config] };
+      }
+      if (getActionType(config) !== "unknown") {
+        config = { actions: [config] };
+      }
+
+      let normalized: AutomationConfig;
 
       try {
-        normalized = normalizeAutomationConfig(loaded);
+        normalized = normalizeAutomationConfig(config);
       } catch (_err: any) {
         return;
       }


### PR DESCRIPTION


## Proposed change

Try to convert the pasted automation in a format we support.

This allows to paste snippets of automations, and automation examples from our documentation.

Not everything is supported yet, like shorthand notations.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
