### PR TITLE
Add background styling options to section settings

### DIFF
--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -6,7 +6,7 @@ export interface LovelaceBaseSectionConfig {
   visibility?: Condition[];
   column_span?: number;
   row_span?: number;
-  background?: number[];
+  background_color?: number[];
   /**
    * @deprecated Use heading card instead.
    */

--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -2,11 +2,15 @@ import type { Condition } from "../../../panels/lovelace/common/validate-conditi
 import type { LovelaceCardConfig } from "./card";
 import type { LovelaceStrategyConfig } from "./strategy";
 
+export interface LovelaceSectionStyleConfig {
+  background_color?: number[];
+}
+
 export interface LovelaceBaseSectionConfig {
   visibility?: Condition[];
   column_span?: number;
   row_span?: number;
-  background_color?: number[];
+  style?: LovelaceSectionStyleConfig;
   /**
    * @deprecated Use heading card instead.
    */

--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -3,7 +3,7 @@ import type { LovelaceCardConfig } from "./card";
 import type { LovelaceStrategyConfig } from "./strategy";
 
 export interface LovelaceSectionStyleConfig {
-  background_color?: number[];
+  background_color?: string;
 }
 
 export interface LovelaceBaseSectionConfig {

--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -6,6 +6,7 @@ export interface LovelaceBaseSectionConfig {
   visibility?: Condition[];
   column_span?: number;
   row_span?: number;
+  background?: number[];
   /**
    * @deprecated Use heading card instead.
    */

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -12,6 +12,7 @@ import "../../../../components/ha-form/ha-form";
 import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
+import { hex2rgb, rgb2hex } from "../../../../common/color/convert-color";
 
 interface SettingsData {
   column_span?: number;
@@ -102,7 +103,9 @@ export class HuiDialogEditSection extends LitElement {
     const data: SettingsData = {
       column_span: this.config.column_span || 1,
       background_type: this._selectorBackgroundType,
-      background_color: this.config.style?.background_color || [],
+      background_color: this.config.style?.background_color
+        ? hex2rgb(this.config.style?.background_color as any)
+        : [],
     };
 
     const schema = this._schema(
@@ -150,7 +153,7 @@ export class HuiDialogEditSection extends LitElement {
     if (newData.background_type === "color") {
       newConfig.style = {
         ...newConfig.style,
-        background_color: newData.background_color,
+        background_color: rgb2hex(newData.background_color as any),
       };
     } else {
       newConfig.style = {

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -91,8 +91,7 @@ export class HuiDialogEditSection extends LitElement {
   protected firstUpdated(_changedProperties: PropertyValues) {
     super.firstUpdated(_changedProperties);
 
-    // Determine the background type based on the config
-    if (this.config.background) {
+    if (this.config.background_color) {
       this._selectorBackgroundType = "color";
     } else {
       this._selectorBackgroundType = "none";
@@ -103,7 +102,7 @@ export class HuiDialogEditSection extends LitElement {
     const data: SettingsData = {
       column_span: this.config.column_span || 1,
       background_type: this._selectorBackgroundType,
-      background_color: this.config.background || [],
+      background_color: this.config.background_color || [],
     };
 
     const schema = this._schema(
@@ -149,9 +148,9 @@ export class HuiDialogEditSection extends LitElement {
     };
 
     if (newData.background_type === "color") {
-      newConfig.background = newData.background_color;
+      newConfig.background_color = newData.background_color;
     } else {
-      newConfig.background = undefined;
+      newConfig.background_color = undefined;
     }
 
     fireEvent(this, "value-changed", { value: newConfig });

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -91,7 +91,7 @@ export class HuiDialogEditSection extends LitElement {
   protected firstUpdated(_changedProperties: PropertyValues) {
     super.firstUpdated(_changedProperties);
 
-    if (this.config.background_color) {
+    if (this.config.style?.background_color) {
       this._selectorBackgroundType = "color";
     } else {
       this._selectorBackgroundType = "none";
@@ -102,7 +102,7 @@ export class HuiDialogEditSection extends LitElement {
     const data: SettingsData = {
       column_span: this.config.column_span || 1,
       background_type: this._selectorBackgroundType,
-      background_color: this.config.background_color || [],
+      background_color: this.config.style?.background_color || [],
     };
 
     const schema = this._schema(
@@ -148,9 +148,15 @@ export class HuiDialogEditSection extends LitElement {
     };
 
     if (newData.background_type === "color") {
-      newConfig.background_color = newData.background_color;
+      newConfig.style = {
+        ...newConfig.style,
+        background_color: newData.background_color,
+      };
     } else {
-      newConfig.background_color = undefined;
+      newConfig.style = {
+        ...newConfig.style,
+        background_color: undefined,
+      };
     }
 
     fireEvent(this, "value-changed", { value: newConfig });

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -110,7 +110,9 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
             "import-only": this.importOnly,
             "has-background": Boolean(background),
           })}"
-          style="background: ${background};"
+          style=${styleMap({
+            background: background,
+          })}
         >
           ${repeat(
             cardsConfig,

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -20,7 +20,6 @@ import "../components/hui-card-edit-mode";
 import { moveCard } from "../editor/config-util";
 import type { LovelaceCardPath } from "../editor/lovelace-path";
 import type { Lovelace } from "../types";
-import { rgb2hex } from "../../../common/color/convert-color";
 
 const CARD_SORTABLE_OPTIONS: HaSortableOptions = {
   delay: 100,
@@ -87,9 +86,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
       ? IMPORT_MODE_CARD_SORTABLE_OPTIONS
       : CARD_SORTABLE_OPTIONS;
 
-    const background = this._config.style?.background_color
-      ? rgb2hex(this._config.style?.background_color as any)
-      : "";
+    const background = this._config.style?.background_color ?? "";
 
     return html`
       <ha-sortable

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -86,7 +86,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
       ? IMPORT_MODE_CARD_SORTABLE_OPTIONS
       : CARD_SORTABLE_OPTIONS;
 
-    const background = this._config.style?.background_color ?? "";
+    const background = this._config.style?.background_color;
 
     return html`
       <ha-sortable

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -87,8 +87,8 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
       ? IMPORT_MODE_CARD_SORTABLE_OPTIONS
       : CARD_SORTABLE_OPTIONS;
 
-    const background = this._config.background_color
-      ? rgb2hex(this._config.background_color as any)
+    const background = this._config.style?.background_color
+      ? rgb2hex(this._config.style?.background_color as any)
       : "";
 
     return html`
@@ -260,7 +260,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
           padding: 0 !important;
         }
         .container.has-background {
-          padding: 0 8px 8px 8px;
+          padding: 8px;
           border-radius: var(--ha-card-border-radius, 12px);
         }
 

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -87,8 +87,8 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
       ? IMPORT_MODE_CARD_SORTABLE_OPTIONS
       : CARD_SORTABLE_OPTIONS;
 
-    const background = this._config.background
-      ? rgb2hex(this._config.background as any)
+    const background = this._config.background_color
+      ? rgb2hex(this._config.background_color as any)
       : "";
 
     return html`

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -20,6 +20,7 @@ import "../components/hui-card-edit-mode";
 import { moveCard } from "../editor/config-util";
 import type { LovelaceCardPath } from "../editor/lovelace-path";
 import type { Lovelace } from "../types";
+import { rgb2hex } from "../../../common/color/convert-color";
 
 const CARD_SORTABLE_OPTIONS: HaSortableOptions = {
   delay: 100,
@@ -86,6 +87,10 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
       ? IMPORT_MODE_CARD_SORTABLE_OPTIONS
       : CARD_SORTABLE_OPTIONS;
 
+    const background = this._config.background
+      ? rgb2hex(this._config.background as any)
+      : "";
+
     return html`
       <ha-sortable
         .disabled=${!editMode}
@@ -103,7 +108,9 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
           class="container ${classMap({
             "edit-mode": editMode,
             "import-only": this.importOnly,
+            "has-background": Boolean(background),
           })}"
+          style="background: ${background};"
         >
           ${repeat(
             cardsConfig,
@@ -249,6 +256,10 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
         .container.import-only {
           border: none;
           padding: 0 !important;
+        }
+        .container.has-background {
+          padding: 0 8px 8px 8px;
+          border-radius: var(--ha-card-border-radius, 12px);
         }
 
         .card {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -436,7 +436,8 @@
       "replace": "Replace",
       "append": "Append",
       "supports_markdown": "Supports {markdown_help_link}",
-      "markdown": "Markdown"
+      "markdown": "Markdown",
+      "none": "None"
     },
 
     "components": {
@@ -7199,7 +7200,11 @@
             "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]",
             "settings": {
               "column_span": "Width",
-              "column_span_helper": "Larger sections will be made smaller to fit the display. (e.g. on mobile devices)"
+              "column_span_helper": "Larger sections will be made smaller to fit the display. (e.g. on mobile devices)",
+              "styling": "Styling",
+              "background_type": "Background type",
+              "background_type_color_option": "Color",
+              "background_color": "Background color"
             },
             "visibility": {
               "explanation": "The section will be shown when ALL conditions below are fulfilled. If no conditions are set, the section will always be shown."


### PR DESCRIPTION
## Proposed change
Add background styling options to section settings, which seems to be a feature request as well (https://github.com/orgs/home-assistant/discussions/492, https://github.com/home-assistant/frontend/discussions/22288). It adds some additional padding to the section to make the cards not stick to the edges. On this basis, we can iterate further, for example, an option without padding.

| <img width="577" height="405" alt="image" src="https://github.com/user-attachments/assets/9c806788-30c7-4d03-9600-f6c09d7c6ae6" /> | <img width="624" height="508" alt="image" src="https://github.com/user-attachments/assets/7dfd71eb-d168-4c54-8637-8173d34cba01" /> |
| :-: | :-: |
| <img width="624" height="505" alt="image" src="https://github.com/user-attachments/assets/9915a0f6-3543-42fb-aba2-0d72d8e7223b" /> | <img width="521" height="573" alt="image" src="https://github.com/user-attachments/assets/bbc6ba6b-451a-439c-b64e-d2c64c5fa8ca" /> |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
